### PR TITLE
WHINT Interface Documentation plugin added

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
         "/plugins/cpitransporter.js",
         "/plugins/figaf.js",
         "/plugins/OpenAIServices.js",
+        "/plugins/WHINT_IFD.js",
         "/scripts/ui.js",
         "/scripts/tools.js",
         "/scripts/logs.js",

--- a/plugins/WHINT_IFD.js
+++ b/plugins/WHINT_IFD.js
@@ -1,0 +1,31 @@
+var plugin = {
+    metadataVersion: "1.0.0",
+    id: "WHINT_IFD",
+    name: "WHINT® Interface Documentation",
+    version: "1.0.",
+    author: "whitepaper.id GmbH",
+    email: "support@whitepaper-id.com",
+    website: "https://whitepaper-id.com",
+    description: "Navigate directly to your Technical Interface Documentation in Microsoft SharePoint. See <a href='https://www.integration-excellence.com/whint-solutions/ifd-sap-cpi/' target='_blank'>integration-excellence.com</a> for more details.",
+    settings: {
+        "spBaseUrl": {"text": "SharePoint URL", "type": "text", scope: "tenant"},
+    },
+    messageSidebarContent: {
+        "static": true,
+        "onRender": (pluginHelper, settings) => {
+
+            const a = document.createElement("a");
+            a.innerText = "Open in SharePoint";
+            a.setAttribute("target", "_blank");
+            a.setAttribute("href", settings[`WHINT_IFD---${pluginHelper.tenant}---spBaseUrl`] +
+                `/${location.pathname.split('/')[5]}_${pluginHelper.integrationFlowId}.pdf?web=1`
+            );
+
+            const div = document.createElement("div")
+            div.appendChild(a);
+            return div;
+        }
+    }
+};
+
+pluginList.push(plugin);


### PR DESCRIPTION
Hi there,

we've created a plugin that allows you to navigate directly to the PDF created by the WHINT® Interface Documentation in SharePoint, see [integration-excellence.com](https://www.integration-excellence.com/whint-solutions/ifd-sap-cpi/ ) for details.

Thanks for merging!
Julia
