### PR TITLE
Minimize overlay & match ui color of overlay header

### DIFF
--- a/contentScript.css
+++ b/contentScript.css
@@ -150,6 +150,8 @@
   color: #fff;
   box-sizing: border-box;
   border-radius: 5px 5px 0px 0px;
+  display: flex;
+  justify-content: space-between;
 }
 
 .cpiHelper .contentText {

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -1246,9 +1246,9 @@ var sidebar = {
     var elem = document.createElement('div');
     elem.innerHTML = `
     <div id="cpiHelper_contentheader">
-        <span id='sidebar_modal_minimize' class='cpiHelper_closeButton_sidebar'>CPI Helper</span>
-        <span id='sidebar_modal_close' style='margin-left: 30px;' class='cpiHelper_closeButton_sidebar'>X</span>
-    </div>
+            <span id='sidebar_modal_minimize' class='cpiHelper_closeButton_sidebar'>CPI Helper</span>
+            <span id='sidebar_modal_close' style='margin-left: 30px;' class='cpiHelper_closeButton_sidebar'>X</span>
+        </div>
     <div id="outerFrame">
     <div id="updatedText" class="contentText"></div>
     <div id="deploymentText" class="contentText">State: </div>
@@ -1262,22 +1262,22 @@ var sidebar = {
     document.body.appendChild(elem);
 
     //add minimize button on CPI helper title & color match with tenant color
-var span = document.getElementById("sidebar_modal_minimize");
-span.onclick = () => {
+    var span = document.getElementById("sidebar_modal_minimize");
     var content_header = document.getElementById("cpiHelper_contentheader");
     var outerFrame_element = document.getElementById("outerFrame");
     var borderofouterFrame = getComputedStyle(outerFrame_element).borderRadius.split(" ");
-    if (outerFrame_element.offsetHeight > 0) {
-        content_header.style['min-width'] = getComputedStyle(outerFrame_element).width
+    span.onclick = () => {   
+        if (outerFrame_element.offsetHeight > 0) {
+            content_header.style['min-width'] = getComputedStyle(outerFrame_element).width
             outerFrame_element.style.display = 'none';
-        content_header.style['border-bottom-left-radius'] = borderofouterFrame[2];
-        content_header.style['border-bottom-right-radius'] = borderofouterFrame[3];
-    } else {
-        outerFrame_element.style.display = 'block';
-        content_header.style['border-bottom-left-radius'] = borderofouterFrame[0];
-        content_header.style['border-bottom-right-radius'] = borderofouterFrame[1];
-    }
-};
+            content_header.style['border-bottom-left-radius'] = borderofouterFrame[2];
+            content_header.style['border-bottom-right-radius'] = borderofouterFrame[3];
+        } else {
+            outerFrame_element.style.display = 'block';
+            content_header.style['border-bottom-left-radius'] = borderofouterFrame[0];
+            content_header.style['border-bottom-right-radius'] = borderofouterFrame[1];
+        }
+    };
 
     //add close button
     var span = document.getElementById("sidebar_modal_close");
@@ -1560,16 +1560,21 @@ function dragElement(elmnt) {
   }
 
   function elementDrag(e) {
-    e = e || window.event;
-    e.preventDefault();
-    // calculate the new cursor position:
-    pos1 = pos3 - e.clientX;
-    pos2 = pos4 - e.clientY;
-    pos3 = e.clientX;
-    pos4 = e.clientY;
-    // set the element's new position:
-    elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
-    elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
+        e = e || window.event;
+        e.preventDefault();
+        // calculate the new cursor position:
+        pos1 = pos3 - e.clientX;
+        pos2 = pos4 - e.clientY;
+        pos3 = e.clientX;
+        pos4 = e.clientY;
+        // set the element's new position:
+        newtop = (elmnt.offsetTop - pos2);
+        newleft = (elmnt.offsetLeft - pos1);
+        maxtop = window.innerHeight - document.getElementById("cpiHelper_contentheader").offsetHeight;
+        maxwidth = window.innerWidth - document.getElementById("cpiHelper_contentheader").offsetWidth;
+        // bounding position based on max top and width. making position relative in case of resize.
+        elmnt.style.top = (((newtop  < 0 || newtop  > maxtop  )?0:(((newtop  < 0) ? 0 : ((newtop  >= maxtop)   ? maxtop   : newtop )))) * 100 / window.innerHeight + "%");
+        elmnt.style.left =(((newleft < 0 || newleft > maxwidth)?0:(((newleft < 0) ? 0 : ((newleft >= maxwidth) ? maxwidth : newleft)))) * 100 / window.innerWidth  + "%");
   }
 
   function closeDragElement() {

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -1262,21 +1262,22 @@ var sidebar = {
     document.body.appendChild(elem);
 
     //add minimize button on CPI helper title & color match with tenant color
-    var span = document.getElementById("sidebar_modal_minimize");
-    span.onclick = () => {   
-      var content_header = document.getElementById("cpiHelper_contentheader");
-        var outerFrame_element = document.getElementById("outerFrame");
-        var borderofouterFrame = getComputedStyle(outerFrame_element).borderRadius.split(" ");
-        if (outerFrame_element.offsetHeight > 0) {
+var span = document.getElementById("sidebar_modal_minimize");
+span.onclick = () => {
+    var content_header = document.getElementById("cpiHelper_contentheader");
+    var outerFrame_element = document.getElementById("outerFrame");
+    var borderofouterFrame = getComputedStyle(outerFrame_element).borderRadius.split(" ");
+    if (outerFrame_element.offsetHeight > 0) {
+        content_header.style['min-width'] = getComputedStyle(outerFrame_element).width
             outerFrame_element.style.display = 'none';
-            content_header.style['border-bottom-left-radius'] = borderofouterFrame[2];
-            content_header.style['border-bottom-right-radius'] = borderofouterFrame[3];
-        } else {
-            outerFrame_element.style.display = 'block';
-            content_header.style['border-bottom-left-radius'] = borderofouterFrame[0];
-            content_header.style['border-bottom-right-radius'] = borderofouterFrame[1];
-        }
-    };
+        content_header.style['border-bottom-left-radius'] = borderofouterFrame[2];
+        content_header.style['border-bottom-right-radius'] = borderofouterFrame[3];
+    } else {
+        outerFrame_element.style.display = 'block';
+        content_header.style['border-bottom-left-radius'] = borderofouterFrame[0];
+        content_header.style['border-bottom-right-radius'] = borderofouterFrame[1];
+    }
+};
 
     //add close button
     var span = document.getElementById("sidebar_modal_close");

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -1245,7 +1245,10 @@ var sidebar = {
     //create sidebar div
     var elem = document.createElement('div');
     elem.innerHTML = `
-    <div id="cpiHelper_contentheader">CPI Helper<span id='sidebar_modal_close' style="float:right;" class='cpiHelper_closeButton_sidebar'>X</span></div> 
+    <div id="cpiHelper_contentheader">
+        <span id='sidebar_modal_minimize' class='cpiHelper_closeButton_sidebar'>CPI Helper</span>
+        <span id='sidebar_modal_close' style='margin-left: 30px;' class='cpiHelper_closeButton_sidebar'>X</span>
+    </div>
     <div id="outerFrame">
     <div id="updatedText" class="contentText"></div>
     <div id="deploymentText" class="contentText">State: </div>
@@ -1257,6 +1260,23 @@ var sidebar = {
     elem.id = "cpiHelper_content";
     elem.classList.add("cpiHelper");
     document.body.appendChild(elem);
+
+    //add minimize button on CPI helper title & color match with tenant color
+    var span = document.getElementById("sidebar_modal_minimize");
+    span.onclick = () => {   
+      var content_header = document.getElementById("cpiHelper_contentheader");
+        var outerFrame_element = document.getElementById("outerFrame");
+        var borderofouterFrame = getComputedStyle(outerFrame_element).borderRadius.split(" ");
+        if (outerFrame_element.offsetHeight > 0) {
+            outerFrame_element.style.display = 'none';
+            content_header.style['border-bottom-left-radius'] = borderofouterFrame[2];
+            content_header.style['border-bottom-right-radius'] = borderofouterFrame[3];
+        } else {
+            outerFrame_element.style.display = 'block';
+            content_header.style['border-bottom-left-radius'] = borderofouterFrame[0];
+            content_header.style['border-bottom-right-radius'] = borderofouterFrame[1];
+        }
+    };
 
     //add close button
     var span = document.getElementById("sidebar_modal_close");

--- a/scripts/identify-tenant.js
+++ b/scripts/identify-tenant.js
@@ -165,7 +165,9 @@
   function setHeaderColor(color) {
     let header = document.querySelector('#shell--toolHeader')
     if (header && header.style && header.style.backgroundColor !== color) {
-      header.style.backgroundColor = color
+      header.style.backgroundColor = color;
+      //sync header with popup header
+      document.querySelector('#cpiHelper_contentheader').style.backgroundColor = color
     }
   }
 


### PR DESCRIPTION
Hello,

Issue:
It a chore to remove and move around this overlay. There is no way to minimize the overlay. When developing multiple deployments is necessary, not when creating I-flow logic (or moving it without removing it). Once we delete it, the only way to return is to reload.

Resolution:
It can be reduced when we click on "CPI Helper". If we click it again then maximize which comes as default. (My personal preference is a header color that matches the outer custom color we choose)

Attachment: 
![Untitled](https://user-images.githubusercontent.com/87596092/230737736-11ed3210-1038-47d7-b5f4-f9067f8c959a.png)

![Untitled](https://user-images.githubusercontent.com/87596092/230734147-a937f51d-8396-4c85-899c-f3cda9351c56.png)
top image when minimized, bottom image when maximized.