### PR TITLE
Update theme-color in the setHeaderColor function

### DIFF
--- a/scripts/identify-tenant.js
+++ b/scripts/identify-tenant.js
@@ -170,6 +170,17 @@
       if (document.querySelector('#cpiHelper_contentheader')) {
         document.querySelector('#cpiHelper_contentheader').style.backgroundColor = color
       }
+      
+      // Set the theme color meta tag
+      let themeColorElement = document.querySelector("meta[name='theme-color']");
+      if (themeColorElement) {
+        themeColorElement.content = color;
+      } else {
+        let newElement = document.createElement('meta');
+        newElement.name = 'theme-color';
+        newElement.content = color;
+        document.head.appendChild(newElement);
+      }
     }
   }
 


### PR DESCRIPTION
A small feature that I wanted myself. I like the idea of using Integration Suite via the "fake app" / "create shortcut" feature of Chrome. This way, it Integration Suite masquerades as an "actual app/program" on my computer. For a tool I might sit with all day it makes sense to have it in its separate app-like window, rather than it getting lost amongst all my browser tabs.

Either way, the "theme-color" tag / feature controls the way the "OS header" is colored. So I felt like implementing this.
It's also in general a tag that does exactly what it sounds like - signalizes the theme-color of the current website to the browser that is running it.
[MSDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)

I added a small piece of logic that updates the "theme-color". It gets updated along with the UI5 header color in the "setHeaderColor" function. Gives the full window top a nice, unified look, and further separates different environments from each other.

