### PR TITLE
remove annoying "flying error dialog"

### DIFF
--- a/contentScript.css
+++ b/contentScript.css
@@ -12,9 +12,7 @@
   visibility: hidden;
   min-width: 10px;
   margin-left: -125px;
-
   color: #fff;
-
   position: fixed;
   z-index: 500;
   right: 10%;
@@ -65,14 +63,16 @@
 
 .cpiHelper button.cpiHelper_sidebar_iconbutton {
   cursor: initial;
-  border: solid 0px;
+  border: solid 2px;
   background: transparent;
   outline: none;
 }
 
 #cpiHelper_sidebar_popup {
   position: fixed;
-  z-index: 460;
+  z-index: 390;
+  max-height: 20vh;
+  overflow: scroll;
   background: #fbfbfb;
   bottom: 50px;
   right: 100px;

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -214,7 +214,7 @@ async function renderMessageSidebar() {
 				activeInlineItem == quickInlineTraceButton.classList[0] && quickInlineTraceButton.classList.add("cpiHelper_inlineInfo-active");
 
 
-				let statusicon = createElementFromHTML("<button class='" + resp[i].MessageGuid + " cpiHelper_sidebar_iconbutton'><span data-sap-ui-icon-content='" + statusIcon + "' class='" + resp[i].MessageGuid + " sapUiIcon sapUiIconMirrorInRTL' style='font-family: SAP-icons; font-size: 0.9rem; color:" + statusColor + ";'> </span></button>");
+				let statusicon = createElementFromHTML("<button class='" + resp[i].MessageGuid + " cpiHelper_inlineInfo-button'><span data-sap-ui-icon-content='" + statusIcon + "' class='" + resp[i].MessageGuid + " sapUiIcon sapUiIconMirrorInRTL' style='font-family: SAP-icons; font-size: 0.9rem; color:" + statusColor + ";'> </span></button>");
         statusicon.onclick = (e) => {
           x = document.getElementById('cpiHelper_sidebar_popup')
           if (!x) {

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -215,15 +215,30 @@ async function renderMessageSidebar() {
 
 
 				let statusicon = createElementFromHTML("<button class='" + resp[i].MessageGuid + " cpiHelper_sidebar_iconbutton'><span data-sap-ui-icon-content='" + statusIcon + "' class='" + resp[i].MessageGuid + " sapUiIcon sapUiIconMirrorInRTL' style='font-family: SAP-icons; font-size: 0.9rem; color:" + statusColor + ";'> </span></button>");
-
-				statusicon.onmouseover = (e) => {
-
-				  errorPopupOpen(e.currentTarget.classList[0]);
-				  errorPopupSetTimeout(null);
-				};
-				statusicon.onmouseout = (e) => {
-				  errorPopupSetTimeout(2000);
-				};
+        statusicon.onclick = (e) => {
+          x = document.getElementById('cpiHelper_sidebar_popup')
+          if (!x) {
+            errorPopupOpen(e.currentTarget.classList[0]);
+            e.currentTarget.classList.add('cpiHelper_sidebar_iconbutton')
+          } else {
+            if (x.getAttribute('class') === 'show' && e.currentTarget.classList.contains('cpiHelper_sidebar_iconbutton')) {
+              errorPopupClose(); e.currentTarget.classList.remove('cpiHelper_sidebar_iconbutton')
+            }
+            else {
+              document.querySelectorAll('.cpiHelper_sidebar_iconbutton').forEach((i) => i.classList.remove('cpiHelper_sidebar_iconbutton'));
+              errorPopupOpen(e.currentTarget.classList[0]);
+              e.currentTarget.classList.add('cpiHelper_sidebar_iconbutton');
+            }
+          }
+        }
+        //earlier code
+				// statusicon.onmouseover = (e) => {
+				//   errorPopupOpen(e.currentTarget.classList[0]);
+				//   errorPopupSetTimeout(null);
+				// };
+				// statusicon.onmouseout = (e) => {
+				//   errorPopupSetTimeout(2000);
+				// };
 
 				quickInlineTraceButton.onmouseup = async (e) => {
 				  var mytarget = e.currentTarget
@@ -1384,12 +1399,8 @@ async function errorPopupOpen(MessageGuid) {
   if (!x) {
     x = document.createElement('div');
     x.id = "cpiHelper_sidebar_popup";
-    x.onmouseover = (e) => {
-      errorPopupSetTimeout(null);
-    };
-    x.onmouseout = (e) => {
-      errorPopupSetTimeout(3000);
-    };
+    //x.onmouseover = (e) => {errorPopupSetTimeout(null)};
+    //x.onmouseout = (e) => {errorPopupSetTimeout(3000)};
     document.body.appendChild(x);
   }
 


### PR DESCRIPTION
#95 - remove annoying "flying error dialog."

This issue has been bothering me as well. Here are the changes I have made

- I removed the timer that automatically closed the dialog after a few seconds, so that the user can read the error log at their own pace.
- I changed the mouse listeners to click events, so that the dialog only pops up when the user clicks on the error icon, instead of hovering over it.
- I set a maximum size for the dialog based on a fraction of the workspace dimensions and added a scroll bar for long logs. This way, the dialog does not take up too much space but - 
- preview as below
![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/87596092/0d829766-0428-46e0-9a3c-7b3622528fc0)

- **Edit: Sorry, realized late but in my opinion css prop: max height: 40vh to 50vh is far better choice in case of long log message. (please update) Thank you**