### PR TITLE
Plugin UI update + few ui changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ It is open source so feel free to check the source code.
 - [Improvement] Improved "flying error dialog". No mouse over but you need to klick now. Thanks to Omkar Patel
 - [Improvement] Many more ui improvements. Thanks to Omkar Patel
 - [Feature] Trace survives page reload
+- [Improvement] Logs now sorted
 - [Bugfix] Many small fixes
 
 ### 3.7.1

--- a/contentScript.css
+++ b/contentScript.css
@@ -499,7 +499,7 @@ div#cpiHelper_messageSidebar_pluginArea {
   height: auto !important;
 }
 
-h3.header {
+#cpiHelper_semanticui_modal h3.header {
   padding: 1em;
   background-color: #21436a;
   color: #fff;

--- a/contentScript.css
+++ b/contentScript.css
@@ -499,8 +499,8 @@ div#cpiHelper_messageSidebar_pluginArea {
   height: auto !important;
 }
 
-#cpiHelper_semanticui_modal h3.header {
-  padding: 1em;
+#cpiHelper_semanticui_modal h4.header {
+  padding: .5em;
   background-color: #21436a;
   color: #fff;
   margin: 0
@@ -516,7 +516,8 @@ div#cpiHelper_messageSidebar_pluginArea {
   }
 }
 
-.card .extra.content:has(input)>label {
+/* .card .extra.content:has(input)>label, */
+.card .extra.content>label {
   display: flex;
   width: 100%;
   height: 100%;
@@ -531,11 +532,13 @@ div#cpiHelper_messageSidebar_pluginArea {
   width: 5em !important
 }
 
-.card .extra.content:has(input:checked)>label {
+/* .card .extra.content:has(input:checked)>label, */
+.card .extra.content.checked>label {
   background: hsl(113, 100%, 85%) !important;
 }
 
-.card .extra.content:has(input:checked)>label::after {
+/* .card .extra.content:has(input:checked)>label::after, */
+.card .extra.content.checked>label::after {
   content: "d";
 }
 

--- a/contentScript.css
+++ b/contentScript.css
@@ -537,14 +537,19 @@ h3.header {
   text-align: center;
   justify-content: center;
   align-items: center;
+  color: #000;
   padding: .5em
 }
 
+
 .card .extra.content:has(input:checked)>label {
-  background: #13af00 !important;
-  color: #fff;
+  background: hsl(113, 100%, 85%) !important;
 }
 
 .card .extra.content:has(input:checked)>label::after {
   content: "d";
+}
+
+.card .extra.content>label:hover {
+  color: hsl(212, 100%, 50%);
 }

--- a/contentScript.css
+++ b/contentScript.css
@@ -495,22 +495,8 @@ button.cpiHelper_sidebar_iconbutton span {
 }
 
 div#cpiHelper_messageSidebar_pluginArea {
-  margin-top: 0.5em;
-}
-
-div#cpiHelper_messageSidebar_pluginArea fieldset {
-  display: block;
-  margin-inline-start: 2px;
-  margin-inline-end: 2px;
-  padding-block-start: 0.35em;
-  padding-inline-start: 0.75em;
-  padding-inline-end: 0.75em;
-  padding-block-end: 0.625em;
-  min-inline-size: min-content;
-  border-width: 2px;
-  border-style: groove;
-  border-color: #c0c0c0;
-  border-image: initial;
+  padding: 1em .5em;
+  height: auto !important;
 }
 
 h3.header {
@@ -541,6 +527,9 @@ h3.header {
   padding: .5em
 }
 
+.ui.fluid.input>input {
+  width: 5em !important
+}
 
 .card .extra.content:has(input:checked)>label {
   background: hsl(113, 100%, 85%) !important;

--- a/contentScript.css
+++ b/contentScript.css
@@ -489,6 +489,7 @@ button.cpiHelper_sidebar_iconbutton span {
   max-height: 100%;
 }
 
+/* plugin */
 .cpiHelper_pluginButton {
   float: right;
 }
@@ -508,6 +509,42 @@ div#cpiHelper_messageSidebar_pluginArea fieldset {
   min-inline-size: min-content;
   border-width: 2px;
   border-style: groove;
-  border-color: #c0c0c0;  /* reverted because it's good to have separation `@ui fix` commit */
+  border-color: #c0c0c0;
   border-image: initial;
+}
+
+h3.header {
+  padding: 1em;
+  background-color: #21436a;
+  color: #fff;
+  margin: 0
+}
+
+.card {
+  width: calc(33% - 1em) !important;
+}
+
+@media screen and (max-width: 1024px) {
+  .card {
+    width: calc(100% - 1em) !important;
+  }
+}
+
+.card .extra.content:has(input)>label {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+  padding: .5em
+}
+
+.card .extra.content:has(input:checked)>label {
+  background: #13af00 !important;
+  color: #fff;
+}
+
+.card .extra.content:has(input:checked)>label::after {
+  content: "d";
 }

--- a/popup.js
+++ b/popup.js
@@ -16,7 +16,7 @@ function addLastVisitedIflows() {
         if (!visitedIflows || visitedIflows.length == 0) {
             return;
         }
-        var compact = document.querySelector('#cpisetting').innerText !== 'Set as Compact';
+        var compact = document.querySelector('#cpisetting>.active').getAttribute('data') !== "true";
         var artifactTypes = ["Package", "IFlow", "Message Mapping", "Script Collection", "Value Mapping", "SOAP API", "REST API", "ODATA API"]
         var html = `<div class="ui horizontal divider header">Last Visited on Tenant ${name.split("_")[1]}</div>`;
         if (compact) {
@@ -101,23 +101,19 @@ function addLastVisitedIflows() {
 function getSideBarAlwaysVisible() {
 
     chrome.storage.sync.get(["openMessageSidebarOnStartup"], function (result) {
-        var openMessageSidebarOnStartupValue = result["openMessageSidebarOnStartup"];
-
-        var openMessageSidebarOnStartup = document.getElementById("openMessageSidebarOnStartup");
-        openMessageSidebarOnStartup.innerText = `Set as ${openMessageSidebarOnStartupValue ? 'No' : 'Yes'}`;
-        openMessageSidebarOnStartup.onclick = function () {
-            let ctnx = openMessageSidebarOnStartup.innerText.split(" ")[2];
-            openMessageSidebarOnStartup.innerText = `Set as ${ctnx !== 'Yes' ? 'Yes' : 'No'}`;
-            console.log(ctnx === 'Yes')
-            chrome.storage.sync.set({ "openMessageSidebarOnStartup": ctnx === 'Yes' });
-        }
+        document.querySelectorAll('#openMessageSidebarOnStartup>.button')[result["openMessageSidebarOnStartup"] ? 0 : 1].classList.add('active')
+        document.querySelector('#openMessageSidebarOnStartup').addEventListener('click', () => {
+            document.querySelectorAll('#openMessageSidebarOnStartup>.button').forEach(e => e.classList.toggle('active'))
+            let ctnx = document.querySelector('#openMessageSidebarOnStartup>.active').getAttribute('data') === 'true';
+            console.log(ctnx)
+            chrome.storage.sync.set({ "openMessageSidebarOnStartup": ctnx });
+        });
     });
 }
 
 function addTenantSettings() {
-    const compactinit = localStorage.getItem('modecpisetting')
-    const tableinit = localStorage.getItem('tablenotetoggle')
-    //<div style="margin-bottom: 0.6em;">use $iflow.name to show current iflow name.</div>
+    const compactinit = localStorage.getItem('modecpisetting')==='true'
+    const tableinit = localStorage.getItem('tablenotetoggle')==='true'
     var tenantSettings = document.getElementById("tenantSettings");
     tenantSettings.innerHTML = `
     <h3 class="ui horizontal divider header">Tenant Settings</h3>
@@ -160,24 +156,22 @@ function addTenantSettings() {
     </div>
     <h3 class="ui horizontal divider header">CPI Helper Settings</h3>
     <div>
-        <div class="ui left labeled button" tabindex="0">
+        <div  id="openMessageSidebarOnStartup" class="ui label buttons">
             <div class="ui label">Open Message Sidebar on start?</div>
-            <div id="openMessageSidebarOnStartup" class="ui blue basic button">Set as Yes</div>
+            <div data=true class="ui toggle basic button">Yes</div>
+            <div data=false class="ui toggle basic button">No</div>
         </div>
-    </div>
-    <div>
-        <div class="ui left labeled button" tabindex="0">
-            <div class="ui label">Mode of Last visited </div>
-            <div id="cpisetting" class="ui blue basic button">Set as ${compactinit === null || compactinit === 'Compact' ? 'Compact' : 'Cozy'}</div>
+        <div id="cpisetting" class="ui label buttons">
+            <div class="ui label">Mode of Last visited</div>
+            <div data=true class="ui toggle basic ${compactinit ? 'active' : ''} button">Cozy</div>
+            <div data=false class="ui toggle basic ${!compactinit ? 'active' : ''} button">Compact</div>
         </div>
-    </div>
-    <div>
-    <div class="ui left labeled button" tabindex="0">
-        <div class="ui label">Need more help/details? </div>
-        <button class="ui toggle ${tableinit === null || tableinit === 'active' ? 'active' : ''} basic button" id="tablenote">
-        ${tableinit === null || tableinit === 'active' ? 'Compress' : 'Expand'}</button>
-    </div>
-    <div class='ui segment ${(tableinit === null || tableinit === ' active') ? '' : 'hidden'}'>
+        <div id="tablenote" class="ui label buttons">
+            <div class="ui label">Need more help/details?</div>
+            <div data=true class="ui toggle basic ${tableinit ? 'active' : ''} button">Expand</div>
+            <div data=false class="ui toggle basic ${!(tableinit) ? 'active' : ''} button">Compress</div>
+        </div>
+        <div class='ui segment ${tableinit ? '' : 'hidden'}'>
 			<div class="ui segment">
 				<div class="ui medium header" style="color:var(--cpi-dark-green)">General Settings</div>
 				<section>
@@ -212,17 +206,13 @@ function addTenantSettings() {
         </div>
     </div>
     `;
-    document.querySelector('#tablenote').classList.add(tableinit == '' ? 'active' : tableinit);
-    document.querySelector('#one > i').classList.add(compactinit === null || compactinit === 'Compact' ? 'expand' : 'compress');
+    document.querySelector('#one > i').classList.add(compactinit ? 'expand' : 'compress');
     document.querySelector('#tenantSettings > div > .buttons > button:nth-child(1)').addEventListener('click', () => inputReset('iflow'));
     document.querySelector('#tenantSettings > div > .buttons > button:nth-child(2)').addEventListener('click', () => inputReset('reset'));
     // Help section btn
     document.querySelector('#tablenote').addEventListener('click', () => {
-        const tabbtn = document.querySelector('#tablenote');
-        const stats = !tabbtn.classList.contains('active');
-        localStorage.setItem('tablenotetoggle', stats ? 'active' : 'inactive');
-        tabbtn.innerText = `${stats ? 'Compress' : 'Expand'}`;
-        tabbtn.classList.toggle('active');
+        document.querySelectorAll('#tablenote>.button').forEach(e => e.classList.toggle('active'))
+        localStorage.setItem('tablenotetoggle', document.querySelector('#tablenote>.active').getAttribute('data') === "true");
         document.querySelector('#tenantSettings>div>div:has(table)').classList.toggle("hidden")
     });
     //reset color btn
@@ -233,10 +223,9 @@ function addTenantSettings() {
     })
     //cozy-compact mode btn
     document.querySelector('#cpisetting').addEventListener('click', () => {
-        const cpisetting = document.querySelector('#cpisetting');
+        localStorage.setItem('modecpisetting', document.querySelector('#cpisetting>.active').getAttribute('data') === "true");
+        document.querySelectorAll('#cpisetting>.button').forEach(e => e.classList.toggle('active'))
         const icon = document.querySelector('#one > i');
-        cpisetting.innerText = `Set as ${cpisetting.innerText === 'Set as Compact' ? 'Cozy' : 'Compact'}`;
-        localStorage.setItem('modecpisetting', cpisetting.innerText.split(' ')[2]);
         icon.classList.toggle('compress');
         icon.classList.toggle('expand');
         addLastVisitedIflows();

--- a/popup.js
+++ b/popup.js
@@ -181,11 +181,15 @@ function addTenantSettings() {
 			<div class="ui segment">
 				<div class="ui medium header" style="color:var(--cpi-dark-green)">General Settings</div>
 				<section>
-					<b class="ui big red text">I-flow page shotcuts</b>  Press Chrome/Edge <span class="ui red text">Alt</span> and Firefox <span
-						class="ui red text">Alt</span> + <span class="ui red text">Shift</span> along with below key.
-					<br />Logs<span class="ui red text">1</span> , Trace <span class="ui red text">2</span> , Messages
-					<span class="ui red text">3</span> , Info <span class="ui red text">4</span> , Plugins <span
-						class="ui red text">5</span>, Search Step <span class="ui red text">S</span>.
+					<b class="ui big red text">I-flow page shotcuts</b><br />
+                    Press Chrome/Edge <kbd class="ui label">Alt</kbd> and Firefox <kbd class="ui label">Alt</kbd> + <kbd class="ui label">Shift</kbd> along with below key.
+                    <div style="padding-block:.5em "></div>
+					<span class="ui basic label">Logs <kbd class="ui label">1</kbd></span> 
+					<span class="ui basic label">Trace <kbd class="ui label">2</kbd></span> 
+					<span class="ui basic label">Messages <kbd class="ui label">3</kbd></span> 
+					<span class="ui basic label">Info <kbd class="ui label">4</kbd></span> 
+					<span class="ui basic label">Plugins <kbd class="ui label">5</kbd></span> 
+					<span class="ui basic label">Search <kbd class="ui label">S</kbd></span> 
 				</section>
 			</div>
 			<div class="ui segment">

--- a/popup.js
+++ b/popup.js
@@ -213,7 +213,7 @@ function addTenantSettings() {
     document.querySelector('#tablenote').addEventListener('click', () => {
         document.querySelectorAll('#tablenote>.button').forEach(e => e.classList.toggle('active'))
         localStorage.setItem('tablenotetoggle', document.querySelector('#tablenote>.active').getAttribute('data') === "true");
-        document.querySelector('#tenantSettings>div>div:has(table)').classList.toggle("hidden")
+        document.querySelector('#tenantSettings > div:nth-child(7) > div.ui.segment').classList.toggle("hidden")//#tenantSettings>div>div:has(table)
     });
     //reset color btn
     document.querySelector('#tenantSettings > div > button').addEventListener('click', () => {

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -1336,9 +1336,11 @@ var sidebar = {
         <div id="deploymentText" class="contentText">State: </div>
         <div><table id="messageList" class="contentText"></table></div>
       </div>
-      <div id="outerPlugin">
-        <div id="cpiHelper_messageSidebar_pluginArea"></div>
-      </div>
+    </div>
+    <div id="cpiHelper_messageSidebar_pluginArea"class="ui sidebar vertical menu"> 
+      <div class="ui centered header">
+      <div class="content">Plugin Page</div>
+      <span data-sap-ui-icon-content="&#xe03e" class='cpiHelper_closeButton_sidebar sapUiIcon sapUiIconMirrorInRTL' style='font-size: 1.2rem;padding-inline-start: 1rem;font-family: SAP-icons'></span>
     </div>
     `;
     elem.id = "cpiHelper_content";
@@ -1951,8 +1953,3 @@ setInterval(async function () {
     nextMessageSidebarRefreshCount = 0;
   }
 }, 3000);
-
-
-
-
-

--- a/scripts/logs.js
+++ b/scripts/logs.js
@@ -323,7 +323,7 @@ createPersistLogsContent = async (messageId) => {
     var tabs = [];
     active = true;
     var count = 0;
-    for (item of entriesList.d.results) {
+    for (item of entriesList.d.results.sort(function (a, b) { return a.MessageStoreId.toLowerCase() > b.MessageStoreId.toLowerCase() ? 1 : -1 })) {
         tabs.push({
             label: item.MessageStoreId,
             content: count == 0 ? await innerpersist({ item: item.Id, count: count }) : innerpersist,
@@ -425,7 +425,7 @@ createRunLogsContent = async (messageId) => {
 
     var tabs = [];
     active = true;
-    for (item of entriesList.d.results) {
+    for (item of entriesList.d.results.sort(function (a, b) { return a.Name.toLowerCase() > b.Name.toLowerCase() ? 1 : -1 })) {
         tabs.push({
             label: item.Name,
             content: async (input) => {

--- a/scripts/plugins.js
+++ b/scripts/plugins.js
@@ -148,7 +148,7 @@ async function createPluginPopupUI(plugin) {
 
     var container = document.createElement('div');
     container.classList.add("card");
-    container.appendChild(createElementFromHTML(`<h3 class="header">${plugin.name}</h3>`));
+    container.appendChild(createElementFromHTML(`<h4 class="header">${plugin.name}</h4>`));
     container.appendChild(createElementFromHTML(`<div class="content">${plugin.description}</div>`));
     if (await getStorageValue(plugin.id, "isActive", null)) {
         if (plugin.settings) {
@@ -165,6 +165,7 @@ async function createPluginPopupUI(plugin) {
                         log.log(checkbox.checked);
                         chrome.storage.sync.set({ [this.key]: this.checked }, function () {
                             log.log(`${plugin.id}--${key}` + " is set to " + checkbox.checked);
+
                         });
                     });
 
@@ -220,13 +221,15 @@ async function createPluginPopupUI(plugin) {
     activeCheckbox.style = "display:none"
     activeCheckbox.checked = await getStorageValue(plugin.id, "isActive")
     activeCheckbox.addEventListener('change', async function () {
+        containerbox = document.querySelector(`#cpiHelper_popup_plugins-${plugin.id}`).parentNode
         log.log(activeCheckbox.checked);
         await syncChromeStoragePromise(getStoragePath(plugin.id, "isActive"), activeCheckbox.checked);
+        activeCheckbox.checked ? containerbox.classList.add('checked') : containerbox.classList.remove('checked');
         statistic("toggle_plugin_active", plugin.id, activeCheckbox.checked)
         showBigPopup(await createContentNodeForPlugins(), "Plugins")
     });
     var div = document.createElement('div');
-    div.classList = "extra content ui toggle";
+    div.classList = `extra content ui toggle ${activeCheckbox.checked ? 'checked' : ""}`;
     div.style.padding = 0;
     div.appendChild(activeCheckbox);
     div.appendChild(createElementFromHTML(`<label for="cpiHelper_popup_plugins-${plugin.id}"> Activate</label>`));

--- a/scripts/plugins.js
+++ b/scripts/plugins.js
@@ -14,9 +14,11 @@ async function messageSidebarPluginContent(forceRender = false) {
         if (settings[element.id + "---isActive"] === true) {
             if (ctxbtnclose.childElementCount == 2) {
                 ctxbtnclose.insertBefore(createElementFromHTML("<span id='sidebar_Plugin' data-sap-ui-icon-content='' class='cpiHelper_closeButton_sidebar sapUiIcon sapUiIconMirrorInRTL' style='font-size: 1.2rem;padding-inline-start: 1rem;font-family: SAP-icons'></span>"), ctxbtnclose.childNodes[2]);
+                document.querySelector("#cpiHelper_messageSidebar_pluginArea span").addEventListener('click', () => {
+                    document.querySelector('#cpiHelper_messageSidebar_pluginArea').classList.remove('visible')
+                })
                 document.querySelector('#sidebar_Plugin').addEventListener('click', () => {
-                    const plugin_element = document.querySelector('#outerPlugin');
-                    plugin_element.style.display = plugin_element.offsetHeight > 0 ? 'none' : 'block'
+                    document.querySelector('#cpiHelper_messageSidebar_pluginArea').classList.toggle('visible')
                 })
             }
             if (element?.messageSidebarContent?.onRender && (!element?.messageSidebarContent?.static || forceRender == true)) {
@@ -24,11 +26,10 @@ async function messageSidebarPluginContent(forceRender = false) {
                 if (!div) {
                     div = document.createElement("fieldset");
                     div.id = "cpiHelper_messageSidebar_pluginArea_" + element.id;
+                    div.classList = "ui fluid segment";
                 }
-
                 div.innerHTML = ""
-
-                div.appendChild(createElementFromHTML("<legend>" + element.name + "</legend>"));
+                div.appendChild(createElementFromHTML("<div class='ui tiny header'>" + element.name + "</div>"));
                 div.appendChild(element.messageSidebarContent.onRender(cpiData, settings));
                 pluginArea.appendChild(div);
             }
@@ -148,7 +149,7 @@ async function createPluginPopupUI(plugin) {
     var container = document.createElement('div');
     container.classList.add("card");
     container.appendChild(createElementFromHTML(`<h3 class="header">${plugin.name}</h3>`));
-    container.appendChild(createElementFromHTML(`<div class="content"><span class="ui label">Version: ${plugin.version}</span><span class="ui label">Id: ${plugin.id}</span><div class="scrolling content description">${plugin.description}</div></div>`));
+    container.appendChild(createElementFromHTML(`<div class="content">${plugin.description}</div>`));
     if (await getStorageValue(plugin.id, "isActive", null)) {
         if (plugin.settings) {
 
@@ -171,7 +172,7 @@ async function createPluginPopupUI(plugin) {
                     checkBoxLabel.htmlFor = checkbox.id;
                     checkBoxLabel.innerText = ` ${plugin.settings[key].text}`;
                     var div = document.createElement('div');
-                    div.classList="ui checkbox toggle";
+                    div.classList = "ui checkbox toggle";
                     div.appendChild(checkbox);
                     div.appendChild(checkBoxLabel);
 
@@ -192,7 +193,7 @@ async function createPluginPopupUI(plugin) {
                         chrome.storage.sync.set({ [this.key]: this.value });
                     });
                     var div = document.createElement('div');
-                    div.classList="ui fluid input"
+                    div.classList = "ui fluid input"
                     div.appendChild(text);
                     div.appendChild(createElementFromHTML(`<div class="ui basic label" for="cpiHelper_popup_plugins-${plugin.id}-${key}"> ${plugin.settings[key].text}</div>`));
                     outerDiv.appendChild(div);
@@ -204,7 +205,7 @@ async function createPluginPopupUI(plugin) {
                     label.innerText = plugin.settings[key].text;
 
                     var div = document.createElement('div');
-                    div.classList="ui label"
+                    div.classList = "ui label"
                     div.appendChild(label);
                     container.appendChild(div);
 

--- a/scripts/plugins.js
+++ b/scripts/plugins.js
@@ -12,8 +12,8 @@ async function messageSidebarPluginContent(forceRender = false) {
         var settings = await getPluginSettings(element.id);
 
         if (settings[element.id + "---isActive"] === true) {
-            if (ctxbtnclose.childElementCount==2) {
-                ctxbtnclose.insertBefore(createElementFromHTML("<span id='sidebar_Plugin' data-sap-ui-icon-content='' class='cpiHelper_closeButton_sidebar sapUiIcon sapUiIconMirrorInRTL' style='font-size: 1.2rem;padding-inline-start: 1rem;font-family: SAP-icons'></span>"),ctxbtnclose.childNodes[2]);
+            if (ctxbtnclose.childElementCount == 2) {
+                ctxbtnclose.insertBefore(createElementFromHTML("<span id='sidebar_Plugin' data-sap-ui-icon-content='' class='cpiHelper_closeButton_sidebar sapUiIcon sapUiIconMirrorInRTL' style='font-size: 1.2rem;padding-inline-start: 1rem;font-family: SAP-icons'></span>"), ctxbtnclose.childNodes[2]);
                 document.querySelector('#sidebar_Plugin').addEventListener('click', () => {
                     const plugin_element = document.querySelector('#outerPlugin');
                     plugin_element.style.display = plugin_element.offsetHeight > 0 ? 'none' : 'block'
@@ -146,36 +146,9 @@ async function createPluginScriptButtons() {
 async function createPluginPopupUI(plugin) {
 
     var container = document.createElement('div');
-    container.classList.add("ui");
-    container.classList.add("segment");
-    container.appendChild(createElementFromHTML(`<h4 class="ui header">${plugin.name} ${plugin.version} ${plugin.id}</h4>`));
-
-    var activeCheckbox = document.createElement('input');
-    activeCheckbox.id = `cpiHelper_popup_plugins-${plugin.id}`;
-    activeCheckbox.type = 'checkbox';
-
-    activeCheckbox.checked = await getStorageValue(plugin.id, "isActive")
-    activeCheckbox.addEventListener('change', async function () {
-        log.log(activeCheckbox.checked);
-        await syncChromeStoragePromise(getStoragePath(plugin.id, "isActive"), activeCheckbox.checked);
-        statistic("toggle_plugin_active", plugin.id, activeCheckbox.checked)
-        showBigPopup(await createContentNodeForPlugins(), "Plugins")
-
-    });
-
-    var div = document.createElement('div');
-    div.classList.add("ui");
-    div.classList.add("checkbox");
-    div.classList.add("toggle");
-    div.appendChild(activeCheckbox);
-    div.appendChild(createElementFromHTML(`<label for="cpiHelper_popup_plugins-${plugin.id}"> activate</label>`));
-    //div.appendChild(createElementFromHTML(`<br>`));
-    div.appendChild(createElementFromHTML(`<div class="ui message">${plugin.description}</div>`));
-    //div.appendChild(createElementFromHTML(`<br>`));
-
-    container.appendChild(div);
-
-
+    container.classList.add("card");
+    container.appendChild(createElementFromHTML(`<h3 class="header">${plugin.name}</h3>`));
+    container.appendChild(createElementFromHTML(`<div class="content"><span class="ui label">Version: ${plugin.version}</span><span class="ui label">Id: ${plugin.id}</span><div class="scrolling content description">${plugin.description}</div></div>`));
     if (await getStorageValue(plugin.id, "isActive", null)) {
         if (plugin.settings) {
 
@@ -197,14 +170,11 @@ async function createPluginPopupUI(plugin) {
                     var checkBoxLabel = document.createElement('label');
                     checkBoxLabel.htmlFor = checkbox.id;
                     checkBoxLabel.innerText = ` ${plugin.settings[key].text}`;
-
                     var div = document.createElement('div');
-                    div.classList.add("ui");
-                    div.classList.add("checkbox");
-                    div.classList.add("toggle");
+                    div.classList="ui checkbox toggle";
                     div.appendChild(checkbox);
                     div.appendChild(checkBoxLabel);
-                    
+
                     container.appendChild(div);
                 }
 
@@ -222,10 +192,7 @@ async function createPluginPopupUI(plugin) {
                         chrome.storage.sync.set({ [this.key]: this.value });
                     });
                     var div = document.createElement('div');
-                    div.classList.add("ui");
-                    div.classList.add("right");
-                    div.classList.add("labeled"); 
-                    div.classList.add("input");
+                    div.classList="ui fluid input"
                     div.appendChild(text);
                     div.appendChild(createElementFromHTML(`<div class="ui basic label" for="cpiHelper_popup_plugins-${plugin.id}-${key}"> ${plugin.settings[key].text}</div>`));
                     outerDiv.appendChild(div);
@@ -237,8 +204,7 @@ async function createPluginPopupUI(plugin) {
                     label.innerText = plugin.settings[key].text;
 
                     var div = document.createElement('div');
-                    div.classList.add("ui");
-                    div.classList.add("label");
+                    div.classList="ui label"
                     div.appendChild(label);
                     container.appendChild(div);
 
@@ -247,9 +213,24 @@ async function createPluginPopupUI(plugin) {
             }
         }
     }
+    var activeCheckbox = document.createElement('input');
+    activeCheckbox.id = `cpiHelper_popup_plugins-${plugin.id}`;
+    activeCheckbox.type = 'checkbox';
+    activeCheckbox.style = "display:none"
+    activeCheckbox.checked = await getStorageValue(plugin.id, "isActive")
+    activeCheckbox.addEventListener('change', async function () {
+        log.log(activeCheckbox.checked);
+        await syncChromeStoragePromise(getStoragePath(plugin.id, "isActive"), activeCheckbox.checked);
+        statistic("toggle_plugin_active", plugin.id, activeCheckbox.checked)
+        showBigPopup(await createContentNodeForPlugins(), "Plugins")
+    });
+    var div = document.createElement('div');
+    div.classList = "extra content ui toggle";
+    div.style.padding = 0;
+    div.appendChild(activeCheckbox);
+    div.appendChild(createElementFromHTML(`<label for="cpiHelper_popup_plugins-${plugin.id}"> Activate</label>`));
+    container.appendChild(div);
     return container;
-
-
 }
 
 //creates the content for the plugin popup
@@ -257,7 +238,7 @@ async function createContentNodeForPlugins() {
 
     var pluginUIList = document.createElement("div")
     pluginUIList.id = "cpiHelper_popup_plugins";
-
+    pluginUIList.classList = 'ui cards'
     for (var element of pluginList) {
         pluginUIList.appendChild(await createPluginPopupUI(element));
     }

--- a/scripts/tools.js
+++ b/scripts/tools.js
@@ -261,7 +261,11 @@ var formatTrace = function (input, id, traceId) {
   }
 
   var formatXml = function (sourceXml) {
-    var xmlDoc = new DOMParser().parseFromString(`<cpi_Helper>${sourceXml}</cpi_Helper>`, 'application/xml');
+    filterflag = 0;
+    var xmlDoc = new DOMParser().parseFromString(`${sourceXml}`, 'application/xml');
+    if (xmlDoc.getElementsByTagName('parsererror').length > 0) {
+      var xmlDoc = new DOMParser().parseFromString(`<cpi_Helper>${sourceXml}</cpi_Helper>`, 'application/xml'); filterflag = 1;
+    }
     var xsltDoc = new DOMParser().parseFromString([
       // describes how we want to modify the XML - indent everything
       '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">',
@@ -280,7 +284,8 @@ var formatTrace = function (input, id, traceId) {
     xsltProcessor.importStylesheet(xsltDoc);
     var resultDoc = xsltProcessor.transformToDocument(xmlDoc);
     var resultXml = new XMLSerializer().serializeToString(resultDoc);
-    return resultXml.substring(12,resultXml.length-13).replaceAll('\n  ','\n');
+    if (filterflag === 1) { resultXml = resultXml.substring(12, resultXml.length - 13).replaceAll('\n  ', '\n'); }
+    return resultXml
   };
 
   var prettify = function (input) {

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -33,7 +33,6 @@ function showToast(title, message, type = "") {
     title,
     message,
     newestOnTop: true
-
   })
     ;
 }
@@ -55,26 +54,15 @@ async function showBigPopup(content, header, parameters = { fullscreen: true, ca
   var textElement = `
   <div>
     <i class="close icon"></i>
-    <div class="header">
-      CPI Helper ${header}
-    </div>
-    <div class="scrolling content">
-      
+    <div class="header">CPI Helper ${header}</div>
+    <div class="scrolling content">      
       <div class="description" id="cpiHelper_bigPopup_content_semanticui" style="min-height: 50vh; transition: all 100ms ease-in-out;">
         <div class="ui active inverted dimmer">
-        <div class="ui loader"></div>
-
+          <div class="ui loader"></div>
+        </div>
       </div>
     </div>
-
-    </div>
-    <div class="actions">
-      <div class="ui black deny button" onclick="$('#cpiHelper_semanticui_modal').modal('hide');">
-        Close
-      </div>
-  
-    </div>
-    </div>
+  </div>
     `;
 
 
@@ -87,7 +75,6 @@ async function showBigPopup(content, header, parameters = { fullscreen: true, ca
   x.id = "cpiHelper_semanticui_modal"
   document.body.appendChild(x);
 
-
   if (parameters.fullscreen) {
     x.classList.add("fullscreen");
   } else {
@@ -95,10 +82,6 @@ async function showBigPopup(content, header, parameters = { fullscreen: true, ca
   }
 
   $('#cpiHelper_semanticui_modal').modal('show');
-
-
-
-
 
 
   var infocontent = document.getElementById("cpiHelper_bigPopup_content_semanticui");

--- a/scripts/whatsNew.js
+++ b/scripts/whatsNew.js
@@ -6,7 +6,7 @@ async function whatsNewCheck(showOnlyOnce = true) {
 
   silentupdates = ["3.0.3"]
 
-  const FIGAF_IMG = chrome.runtime.getURL("images/figaf-editor.png");
+  const FIGAF_IMG = chrome.runtime.getURL("images/figaf_logo-or3aup2a4kcerbzkw8qe9fj133kv700baqsm2nnpj4.png");
 
   if (!check && !silentupdates.includes(manifestVersion) || showOnlyOnce == false) {
     html = `<div class="ui icon positive message">
@@ -34,12 +34,12 @@ async function whatsNewCheck(showOnlyOnce = true) {
                   </div>
                   <div class="ten wide column">
                     <div class="ui header">This release is sponsored by Figaf </div>
-                    <p>Figaf has improved the developer workflow with CPIHelper. It will allows you to go to Figaf
-                      from a Groovy or XSLT Editor. In Figaf you can also run the code with your existing test
-                      cases from the editor. Once you have checked the result, click upload, and the script is in
-                      your iFlow.
+                    <p>Figaf continues to get better at helping with your SAP PI to Integration Suite migration. We are now able to migrate B2B mappings from SAP PI/PO so you keep the invesment from your message mappings. 
+ 
+                    </p><p>B2B migration will be possible from 2311 release. It will contain migration of message mappings even with function library. Testing with SAP PI Messages and integration with B2B Trading Partner Management. This will be first release with a number of limitations but we will improve with customer feedback.  
+                    
                     </p>
-                    Read more <a href="https://figaf.com/cpihelper8" target="_blank"><u>here</u></a>.
+                    Read more <a href="https://figaf.com/cpihelper9" target="_blank"><u>here</u></a>.
                   </div>
                 </div>
               </div>
@@ -75,6 +75,12 @@ async function whatsNewCheck(showOnlyOnce = true) {
                   <div class="description">Improved Plugin UI</div>
                 </div>
               </a>
+              <a class="item"><i class="right triangle icon"></i>
+              <div class="content">
+                <div class="header">Improvement</div>
+                <div class="description">Log-tabs are now sorted</div>
+              </div>
+            </a>
                 <a class="item"><i class="right triangle icon"></i>
                   <div class="content">
                     <div class="header">Bugfix</div>

--- a/scripts/whatsNew.js
+++ b/scripts/whatsNew.js
@@ -70,6 +70,12 @@ async function whatsNewCheck(showOnlyOnce = true) {
                   </div>
                 </a>
                 <a class="item"><i class="right triangle icon"></i>
+                <div class="content">
+                  <div class="header">Feature</div>
+                  <div class="description">Improved Plugin UI</div>
+                </div>
+              </a>
+                <a class="item"><i class="right triangle icon"></i>
                   <div class="content">
                     <div class="header">Bugfix</div>
                     <div class="description">Many bugfixes</div>


### PR DESCRIPTION
Plugin UI update #107.

I have updated the plugin UI to separate the plugin page from the popup bar. This is because the height of the message and plugins together was too big and cluttered. Now, you can open the plugin page from the icon on the sidebar. The plugin page is fixed and not movable.

Here is a screenshot of the new UI:

![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/87596092/b0b996e1-fbc8-4d30-8610-f7edc475f06c)
![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/87596092/edebf594-5d00-43fe-b1a4-53f213a43290)
Removed Close button from bottom because it has a redundant button.

Please let me know if you encounter any issue with the update.

Best regards,
Omkar


Edit: can you please sync the pull request and dev branch.