### PR TITLE
Minor Bug Fixes and improvements

### DIFF
--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -1550,7 +1550,8 @@ async function getMessageProcessingLogRuns(MessageGuid, store = true) {
   return makeCallPromise("GET", "/" + cpiData.urlExtension + "odata/api/v1/MessageProcessingLogs('" + MessageGuid + "')/Runs?$inlinecount=allpages&$format=json&$top=200", store).then((responseText) => {
     var resp = JSON.parse(responseText);
     var status = resp.d.results[0].OverallState;
-    if (resp.d.results.length > 1 && status != "COMPLETED") { return resp.d.results[1].Id; }
+    //take the correct run log (last or second last) for displaying the inline trace, depending on message status.
+    if (resp.d.results.length > 1 && (status != "COMPLETED" && status != "ESCALATED")) { return resp.d.results[1].Id; }
     else { return resp.d.results[0].Id; }
   }).then((runId) => {
     return makeCallPromise("GET", "/" + cpiData.urlExtension + "odata/api/v1/MessageProcessingLogRuns('" + runId + "')/RunSteps?$inlinecount=allpages&$format=json&$top=300", store);

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -210,8 +210,13 @@ async function renderMessageSidebar() {
               statusColor = "#C70039";
               statusIcon = "";
             }
-            if (resp[i].Status.match(/^(ESCALATED|RETRY|CANCELLED)$/)) {
+            if (resp[i].Status.match(/^(ESCALATED|RETRY)$/)) {
+
               statusColor = "#ff8300";
+              statusIcon = "";
+            }
+            if (resp[i].Status.match(/^(CANCELLED)$/)) {
+              statusColor = "#7f7f7f";
               statusIcon = "";
             }
 
@@ -1465,8 +1470,13 @@ async function errorPopupOpen(MessageGuid) {
 
     let status = document.createElement("div");
     status.className = "contentText";
-    status.innerText = "Status: " + customHeaders.CustomStatus
+    status.innerText = "Status: " + customHeaders.Status
     y.appendChild(status)
+    
+    let customstatus = document.createElement("div");
+    customstatus.className = "contentText";
+    customstatus.innerText = "Custom Status: " + customHeaders.CustomStatus
+    y.appendChild(customstatus)
 
 
     let text = document.createElement("div");


### PR DESCRIPTION
- Minor Bug Fix: if a message ends with Escalation End and was previously retried a few times (by a JMS or DS sender), the inline trace picked the wrong run log (not the last but the second last one) to show the steps. 

- Minor fix in the error popup: 

(Main) message status added:
![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/14195212/3f6d2c21-be19-4d43-b6cd-baa18ada9de5)

- Small improvement in message list: Cancelled messages grayed out: 

![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/14195212/eec6d031-3ad1-43cf-8215-97812c05f702)
