### PR TITLE
[Feature] Adding performance stat

### DIFF
--- a/css/contentScript.css
+++ b/css/contentScript.css
@@ -242,23 +242,23 @@ button.cpiHelper_sidebar_iconbutton span {
 }
 
 .cpiHelper_inlineInfo.cpiHelper_avg {
-  fill: #dcddde !important;
+  fill: #82ff82 !important;
 }
 
 .cpiHelper_inlineInfo.cpiHelper_belowavg {
-  fill: #6dffff !important;
+  fill: #82ffff !important;
 }
 
 .cpiHelper_inlineInfo.cpiHelper_aboveavg {
-  fill: #ffe21f !important;
+  fill: #ffff82 !important;
 }
 
 .cpiHelper_inlineInfo.cpiHelper_max {
-  fill: #ff851b !important;
+  fill: #ff8282 !important;
 }
 
 .cpiHelper_inlineInfo.cpiHelper_min {
-  fill: #dc73ff !important;
+  fill: #8282ff !important;
 }
 
 #cpiHelper_bigPopup {
@@ -412,7 +412,7 @@ button.cpiHelper_sidebar_iconbutton span {
 }
 
 .cpiHelper_powertrace {
-  color: red !important
+  color: #ff0000 !important
 }
 
 .cpiHelper_traceText.cpiHelper_traceText_active {
@@ -458,7 +458,7 @@ button.cpiHelper_sidebar_iconbutton span {
 }
 
 .cpiHelper_logs_selected_button {
-  background-color: lightblue !important;
+  background-color: #add8e6 !important;
 }
 
 .cpiHelper_logs_table_div {
@@ -514,7 +514,7 @@ div#cpiHelper_messageSidebar_pluginArea {
 
 /* .card .extra.content:has(input:checked)>label, */
 .card .extra.content.checked>label {
-  background: hsl(113, 100%, 85%) !important;
+  background: #bbffb3 !important;
 }
 
 /* .card .extra.content:has(input:checked)>label::after, */
@@ -524,7 +524,7 @@ div#cpiHelper_messageSidebar_pluginArea {
 
 .card .extra.content>label:hover {
   color: #21436a;
-  background: hsl(0, 100%, 85%)
+  background: #ffb3b3
 }
 
 fieldset {
@@ -534,4 +534,11 @@ fieldset {
 .ui.modal.active>.header {
   background: var(--cpi-custom-color);
   color: #fff;
+}
+
+
+/* traceModifer Css */
+.traceModifer .fluid {
+  background: #ff8282;
+  background: linear-gradient(-90deg, #ff8282 0%, #ffff82 25%, #82ff82 50%, #82ffff 75%, #8282ff 100%) !important;
 }

--- a/css/contentScript.css
+++ b/css/contentScript.css
@@ -67,7 +67,7 @@
 }
 
 .cpiHelper button {
-  --cpi-width:1px;
+  --cpi-width: 1px;
   cursor: pointer;
   border: solid var(--cpi-width) #d2d2d2;
   border-radius: 4px;
@@ -76,7 +76,7 @@
   margin-inline: 0.1em
 }
 
-.cpiHelper table button{
+.cpiHelper table button {
   border: solid var(--cpi-width) #fff;
 }
 
@@ -241,6 +241,25 @@ button.cpiHelper_sidebar_iconbutton span {
   stroke: #ff6b6b !important;
 }
 
+.cpiHelper_inlineInfo.cpiHelper_avg {
+  fill: #dcddde !important;
+}
+
+.cpiHelper_inlineInfo.cpiHelper_belowavg {
+  fill: #6dffff !important;
+}
+
+.cpiHelper_inlineInfo.cpiHelper_aboveavg {
+  fill: #ffe21f !important;
+}
+
+.cpiHelper_inlineInfo.cpiHelper_max {
+  fill: #ff851b !important;
+}
+
+.cpiHelper_inlineInfo.cpiHelper_min {
+  fill: #dc73ff !important;
+}
 
 #cpiHelper_bigPopup {
   display: none;

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   },
   "name": "SAP CPI Helper",
   "short_name": "CPI Helper",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "Extends the SAP Cloud Platform Integration with some useful features to improve usability.",
   "author": "Dominic Beckbauer",
   "homepage_url": "https://github.com/dbeck121/CPI-Helper-Chrome-Extension",

--- a/plugins/traceModifer.js
+++ b/plugins/traceModifer.js
@@ -65,18 +65,18 @@ var plugin = {
                 }
             })
             div.appendChild(inputtrace)
+            div.innerHTML += `<div class="ui divider"></div>`
             var btn = document.createElement("div");
             btn.classList = "ui checkbox"
             btn.innerHTML = `<input type="checkbox" id="traceModifer_box"><label>Performance Status</label>`
             var stats = document.createElement("div");
-            stats.classList = "ui traceModifer wrapped wrapping buttons"
+            stats.appendChild(btn)
+            stats.classList = "traceModifer"
             stats.innerHTML += `
-            <div class="ui basic button" data-variation="purple" data-tooltip="Min"><i class="battery empty icon purple"></i></div>
-            <div class="ui basic button" data-variation="teal" data-tooltip="Below Avg"><i class="battery quarter icon teal"></i></div>
-            <div class="ui basic button" data-variation="grey" data-tooltip="Avg"><i class="battery half icon grey"></i></div>
-            <div class="ui basic button" data-variation="yellow" data-tooltip="Above Avg"><i class="battery three quarters icon yellow"></i></div>
-            <div class="ui basic button" data-variation="orange" data-tooltip="Max"><i class="battery full icon orange"></i></div>`
-            div.appendChild(btn)
+            <div class="ui buttons fluid segment">
+                <label class="ui violet mini circular left bottom floating label">MIN</label>
+                <label class="ui red mini circular right bottom floating label">MAX</label>
+            </div>`
             div.appendChild(stats);
             return div;
         }

--- a/plugins/traceModifer.js
+++ b/plugins/traceModifer.js
@@ -19,18 +19,19 @@ clearalldata = () => {
 }
 
 var plugin = {
-    metadataVersion: "1.0.2",
+    metadataVersion: "1.1.0",
     id: "traceModifer",
     name: "Trace Step Modifier (Beta)",
-    version: "1.0.2",
-    author: "incpi",
+    version: "1.1.0",
+    author: "Developed by Omkar",
     email: "omk14p@outlook.com",
     website: "https://incpi.github.io",
     description: `The CPI Helper plugin lets developers use trace step modifiers in integration flows.<br/>
-     But be careful: the plugin changes the global variable you set for each flow. it will use global instead if input is blank.`,
+     But be careful: the plugin changes the global variable you set for each flow. it will use global instead if input is blank. <a href="https://incpi.github.io/cpihelper-plugin/">Read More</a><br>
+     New Feature: Performance Statatics checkbox to enable inline trace.`,
     settings: {
         "detail": {
-            "type": "text", "class": "ui segment", "text": "Set null which will use global.<br/>Set Global (Scope: browser)<br/>Set flow modifer count (Scope: Iflow)"
+            "type": "text", "class": "ui fluid segment", "text": "Set null which will use global.<br/>Set Global (Scope: browser)<br/>Set flow modifer count (Scope: Iflow)"
         },
         "text": {
             "type": "text", "text": `Enter a number or leave blank. 0 => traces all steps and may freeze your browser. <br /> Blank => uses the global variable from the extension page.
@@ -42,9 +43,10 @@ var plugin = {
         "static": true,
         "onRender": (pluginHelper, settings) => {
             var div = document.createElement("div");
-            div.classList = "ui mini input"
-            div.innerHTML = `<input type="number" id="traceModifer_${pluginHelper.currentArtifactId}" placeholder="Global"  min="0" name="cpi_traceModifer_mode">`;
-            const inputSteps = div.querySelector(`#traceModifer_${pluginHelper.currentArtifactId}`)
+            var inputtrace = document.createElement("div");
+            inputtrace.classList = "ui mini fluid input"
+            inputtrace.innerHTML = `<input type="number" id="traceModifer_${pluginHelper.currentArtifactId}" placeholder="Global"  min="0" name="cpi_traceModifer_mode"><br/>`;
+            const inputSteps = inputtrace.querySelector(`#traceModifer_${pluginHelper.currentArtifactId}`)
             chrome.storage.local.get([`traceModifer_${pluginHelper.currentArtifactId}`], (result) => {
                 data = result[`traceModifer_${pluginHelper.currentArtifactId}`];
                 inputSteps.value = ((data !== null && data !== undefined) || data != "") ? parseInt(data) : 0
@@ -62,7 +64,20 @@ var plugin = {
                     chrome.storage.local.set(JSON.parse(`{ "traceModifer_${pluginHelper.currentArtifactId}":"${data}"}`))
                 }
             })
-
+            div.appendChild(inputtrace)
+            var btn = document.createElement("div");
+            btn.classList = "ui checkbox"
+            btn.innerHTML = `<input type="checkbox" id="traceModifer_box"><label>Performance Status</label>`
+            var stats = document.createElement("div");
+            stats.classList = "ui traceModifer wrapped wrapping buttons"
+            stats.innerHTML += `
+            <div class="ui basic button" data-variation="purple" data-tooltip="Min"><i class="battery empty icon purple"></i></div>
+            <div class="ui basic button" data-variation="teal" data-tooltip="Below Avg"><i class="battery quarter icon teal"></i></div>
+            <div class="ui basic button" data-variation="grey" data-tooltip="Avg"><i class="battery half icon grey"></i></div>
+            <div class="ui basic button" data-variation="yellow" data-tooltip="Above Avg"><i class="battery three quarters icon yellow"></i></div>
+            <div class="ui basic button" data-variation="orange" data-tooltip="Max"><i class="battery full icon orange"></i></div>`
+            div.appendChild(btn)
+            div.appendChild(stats);
             return div;
         }
     },

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -680,8 +680,15 @@ async function showInlineTrace(MessageGuid) {
       try {
         let target;
         let element;
+        let flag = true
         //    let target = element.children[getChild(element, ["g"])];
         //    target = target.children[getChild(target, ["rect", "circle", "path"])];
+
+        if (/StartEvent/.test(run.ModelStepId)) {
+          element = document.getElementById("BPMNShape_" + run.ModelStepId);
+          target = element.children[0].children[0];
+          flag = false
+        }
 
         if (/EndEvent/.test(run.StepId)) {
           element = document.getElementById("BPMNShape_" + run.StepId);
@@ -710,10 +717,11 @@ async function showInlineTrace(MessageGuid) {
 
         target.classList.add("cpiHelper_inlineInfo");
         //     target.addEventListener("onclick", function abc(event) { clickTrace(event); });
-        element.classList.add("cpiHelper_onclick");
-        element.onclick = clickTrace;
-        onClicKElements.push(element);
-
+        if (flag) {
+          element.classList.add("cpiHelper_onclick");
+          element.onclick = clickTrace;
+          onClicKElements.push(element);
+        }
         if (run.Error) {
           target.classList.add("cpiHelper_inlineInfo_error");
         }
@@ -746,7 +754,7 @@ async function showInlineTrace(MessageGuid) {
 
       } catch (e) {
         log.log("no element found for " + run.StepId);
-        log.log(run);
+        log.log(run, e);
       }
 
       return resolve(true);

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -189,7 +189,6 @@ async function renderMessageSidebar() {
             let traceButton = createElementFromHTML("<button title='jump to trace page' id='trace--" + i + "' class='" + resp[i].MessageGuid + flash + "'>" + loglevel.substr(0, 1).toUpperCase() + "</button>");
 
             if (loglevel.toLowerCase() === "trace") {
-
               var quickInlineTraceButton = createElementFromHTML("<button title='activate inline trace for debugging' class='" + resp[i].MessageGuid + flash + " cpiHelper_inlineInfo-button' style='cursor: pointer;'><span data-sap-ui-icon-content='' class='sapUiIcon sapUiIconMirrorInRTL' style='font-family: SAP-icons; font-size: 0.9rem;'></span></button>");
             } else {
               var quickInlineTraceButton = createElementFromHTML("<span />")
@@ -259,11 +258,8 @@ async function renderMessageSidebar() {
             quickInlineTraceButton.onmouseup = async (e) => {
               var mytarget = e.currentTarget
               if (activeInlineItem == e.currentTarget.classList[0]) {
-
                 hideInlineTrace();
                 showToast("Inline-Debugging Deactivated");
-
-
               } else {
                 hideInlineTrace();
                 var inlineTrace = await showInlineTrace(e.currentTarget.classList[0]);
@@ -588,8 +584,7 @@ async function hideInlineTrace() {
 
   activeInlineItem = null;
 
-  var classesToBedeleted = ["cpiHelper_inlineInfo", "cpiHelper_inlineInfo_error", "cpiHelper_inlineInfo-active"]
-
+  var classesToBedeleted = ["cpiHelper_inlineInfo", "cpiHelper_inlineInfo_error", "cpiHelper_avg", "cpiHelper_belowavg", "cpiHelper_inlineInfo-active", "cpiHelper_aboveavg", "cpiHelper_max", "cpiHelper_min"]
   onClicKElements.forEach((element) => {
     if (element.onclick) {
       element.onclick = null;
@@ -606,12 +601,28 @@ async function hideInlineTrace() {
         //elements[i].removeEventListener('onclick', clickTrace);
       }
       elements[i].classList.remove(element)
-
     }
   });
 }
 
+function timenodediff(e) {
+  return {
+    "StepId": e.StepId, "ModelStepId": e.ModelStepId,
+    "CH_stats": parseInt(e.StepStop.match(/\d+/)[0]) - parseInt(e.StepStart.match(/\d+/)[0])
+  }
+}
+
+function maxNode(arr) {
+  let max = arr[0];
+  for (var i = 1; i < arr.length; i++) {
+    max = (arr[i] > max) ? arr[i] : max
+  }
+  return max
+};
+
 var inlineTraceElements;
+let cpi_timediff_list;
+let cpi_max_node;
 async function createInlineTraceElements(MessageGuid) {
   return new Promise(async (resolve, reject) => {
     inlineTraceElements = [];
@@ -621,18 +632,35 @@ async function createInlineTraceElements(MessageGuid) {
     if (logRuns == null || logRuns.length == 0) {
       return resolve(0);
     }
-
     logRuns.forEach((run) => {
       inlineTraceElements.push({
         StepId: run.StepId,
         ModelStepId: run.ModelStepId,
         ChildCount: run.ChildCount,
+        StepStop: run.StepStop,
+        StepStart: run.StepStart,
         RunId: run.RunId,
         BranchId: run.BranchId,
         Error: run.Error
       });
     });
 
+    // res is dataXHR request....
+    if (await getStorageValue('traceModifer', "isActive", null)) {
+      if (Array.isArray(logRuns) && document.getElementById("traceModifer_box").checked) {
+        cpi_sorted_nodes = [];
+        cpi_nodes = logRuns.filter((e) => { return e.StepStart != null && e.StepStop != null ? true : false }).map(timenodediff)
+        cpi_sorted_nodes = cpi_nodes.toSorted((a, b) => a.CH_stats - b.CH_stats);
+        cpi_timediff_list = [];
+        for (i in cpi_nodes) {
+          (cpi_timediff_list.includes(cpi_nodes[i].CH_stats)) ? "" : cpi_timediff_list.push(cpi_nodes[i].CH_stats)
+        }
+        cpi_group_node = Object.groupBy(cpi_sorted_nodes, (e) => { return e.ModelStepId })
+        cpi_max_node = []
+        for (const key in cpi_group_node) { cpi_max_node.push(maxNode(cpi_group_node[key])) }
+
+      }
+    }
     return resolve(logRuns.length);
   });
 }
@@ -643,7 +671,7 @@ async function showInlineTrace(MessageGuid) {
   return new Promise(async (resolve, reject) => {
     var observerInstalled = false;
     var logRuns = await createInlineTraceElements(MessageGuid);
-
+    var Trace_bool = await getStorageValue('traceModifer', "isActive", null)
     if (logRuns == null || logRuns == 0) {
       return resolve(null);
     }
@@ -654,8 +682,6 @@ async function showInlineTrace(MessageGuid) {
         let element;
         //    let target = element.children[getChild(element, ["g"])];
         //    target = target.children[getChild(target, ["rect", "circle", "path"])];
-
-
 
         if (/EndEvent/.test(run.StepId)) {
           element = document.getElementById("BPMNShape_" + run.StepId);
@@ -691,9 +717,16 @@ async function showInlineTrace(MessageGuid) {
         if (run.Error) {
           target.classList.add("cpiHelper_inlineInfo_error");
         }
-
+        if (Trace_bool && document.getElementById("traceModifer_box").checked) {
+          indexofnode = cpi_timediff_list.findIndex(e => e === (cpi_max_node.find((f) => f.ModelStepId === run.ModelStepId)).CH_stats);
+          if (indexofnode == cpi_timediff_list.length - 1) { nodeclass = 'cpiHelper_max' }
+          else if (indexofnode == 0) { nodeclass = "cpiHelper_min" }
+          else if (indexofnode == (cpi_timediff_list.length % 2 === 0 ? cpi_timediff_list.length / 2 : Math.round(cpi_timediff_list.length / 2) - 1)) { nodeclass = 'cpiHelper_avg' }
+          else if (indexofnode < cpi_timediff_list.length / 2) { nodeclass = 'cpiHelper_belowavg' }
+          else if (indexofnode > cpi_timediff_list.length / 2) { nodeclass = 'cpiHelper_aboveavg' }
+          target.classList.add(nodeclass)
+        }
         if (!observerInstalled) {
-
           observer = new MutationObserver((mutations) => {
             mutations.forEach((mutation) => {
               const el = mutation.target;
@@ -801,15 +834,14 @@ async function buildButtonBar() {
   try {
     var headerBar = document.getElementById('__xmlview0--iflowObjectPageHeader-identifierLine');
     headerBar.style.paddingBottom = "0px";
-  } catch (e) {  }
+  } catch (e) { }
 
-	// get status of powertrace button 
+  // get status of powertrace button 
   var powertraceText = await refreshPowerTrace();
-  
   if (!document.getElementById("__buttonxx")) {
     whatsNewCheck();
     //timer for recruiting popup in 100 seconds
-    if(recrutingTimerSet == false) {
+    if (recrutingTimerSet == false) {
       setTimeout(() => {
         recrutingPopup();
       }, 600000);
@@ -905,14 +937,12 @@ async function buildButtonBar() {
     }
   }
 
-	// reapply status of powertrace button (needed after returning from script/message mapping
-    await refreshPowerTrace();
-
+  // reapply status of powertrace button (needed after returning from script/message mapping
+  await refreshPowerTrace();
 }
 
 //Collect Infos to Iflow
 async function getIflowInfo(callback, silent = false) {
-
   return makeCallPromise("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListCommand", false, null, null, null, null, !silent).then((response) => {
     response = new XmlToJson().parse(response)["com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListResponse"];
     var resp = response.artifactInformations;
@@ -1281,7 +1311,7 @@ async function openIflowInfoPopup() {
     recrutingButton.classList.add("button")
 
     var lang = navigator.language || navigator.userLanguage;
-  
+
     if (lang == "de-DE") {
       recrutingButton.innerText = "Werde Berater bei Kangoolutions";
       recrutingButton.addEventListener("click", (a) => {
@@ -1707,7 +1737,7 @@ async function checkURLchange() {
 
 //this function is fired when the url changes
 async function handleUrlChange() {
-    //check if powertrace button was on / set correct button status
+  //check if powertrace button was on / set correct button status
   await refreshPowerTrace();
 
   //check current artifact
@@ -1925,29 +1955,29 @@ async function storeVisitedIflowsForPopup() {
 }
 
 async function refreshPowerTrace() {
-    //get last run from store and check if it is less than 11 minutes ago, then reapply trace button status
+  //get last run from store and check if it is less than 11 minutes ago, then reapply trace button status
 
-    var powertraceText = ""
+  var powertraceText = ""
 
-    var objName = `${cpiData.integrationFlowId}_powertraceLastRefresh`
-    var timeAsStringOrNull = await storageGetPromise(objName)
+  var objName = `${cpiData.integrationFlowId}_powertraceLastRefresh`
+  var timeAsStringOrNull = await storageGetPromise(objName)
 
-    if (timeAsStringOrNull != null && timeAsStringOrNull != undefined) {
-      var now = new Date().getTime()
-      var time = now - parseInt(timeAsStringOrNull)
-      if (time != NaN && time < 1000 * 60 * 11) {
-        log.debug("update powertrace button status")
-        powertraceText = "cpiHelper_powertrace"
+  if (timeAsStringOrNull != null && timeAsStringOrNull != undefined) {
+    var now = new Date().getTime()
+    var time = now - parseInt(timeAsStringOrNull)
+    if (time != NaN && time < 1000 * 60 * 11) {
+      log.debug("update powertrace button status")
+      powertraceText = "cpiHelper_powertrace"
 
-        // if button list already exists (e.g. after url change), reapply class to button
-        var btn = document.getElementById("button134345-BDI-content")  
-        if (btn != undefined && !btn.classList.contains("cpiHelper_powertrace")) {
-	        btn.classList.toggle("cpiHelper_powertrace")
-	      }
+      // if button list already exists (e.g. after url change), reapply class to button
+      var btn = document.getElementById("button134345-BDI-content")
+      if (btn != undefined && !btn.classList.contains("cpiHelper_powertrace")) {
+        btn.classList.toggle("cpiHelper_powertrace")
       }
     }
-    return powertraceText;
   }
+  return powertraceText;
+}
 
 //start
 checkURLchange();


### PR DESCRIPTION
Hello Everyone,

#88 Idea: performance stats,
 Here are some options I came up with:

1. it is not feasible. It uses a height map with different colors, but it causes confusion and crashes when the integration is large.
2. Use a limited height map with the same color but vary the intensity according to the time consumed by each node.
3. Use a five-stage color map that indicates the performance level of each integration (min, below average, average, above average, max).
4. Use a simple visualization that shows only the minimum and maximum nodes of each integration.

I think option 3 is the best one because it is more stable than above. But I would like to hear your opinions and suggestions as well.

You can see a preview of how it would look like here:
![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/87596092/b1ebebe1-b1f4-4890-92c9-47f4de7df525)
New EDIT:
![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/87596092/ab25e157-7b82-4e61-b522-66cc6adccc5b)

Note: 
`Dear Safari users,
This feature is only supported in the Safari browser (dev version) for now. 
Thank you.`
Best regards,
Omkar