### PR TITLE
Update contentScript.js

### DIFF
--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -116,8 +116,10 @@ async function renderMessageSidebar() {
   //get the messagelogs for current iflow
   //var xhr = await makeCallPromiseXHR("GET", "/" + cpiData.urlExtension + "odata/api/v1/MessageProcessingLogs?$filter=IntegrationFlowName eq '" + iflowId + "' and Status ne 'RETRY' and Status ne 'DISCARDED'&$top=" + numberEntries + "&$format=json&$orderby=LogEnd desc", false, null, null, false, "", false)
   // 18.4.2024, Addor: changed back to include Retry (for JMS based sender adapters it's crucial to see hanging messages in the sidebar)
-  var xhr = await makeCallPromiseXHR("GET", "/" + cpiData.urlExtension + "odata/api/v1/MessageProcessingLogs?$filter=IntegrationFlowName eq '" + iflowId + "' and Status ne 'DISCARDED'&$top=" + numberEntries + "&$format=json&$orderby=LogEnd desc", false, null, null, false, "", false)
-
+  //var xhr = await makeCallPromiseXHR("GET", "/" + cpiData.urlExtension + "odata/api/v1/MessageProcessingLogs?$filter=IntegrationFlowName eq '" + iflowId + "' and Status ne 'DISCARDED'&$top=" + numberEntries + "&$format=json&$orderby=LogEnd desc", false, null, null, false, "", false)
+//24-04-2024, On some tenants there are Retry messages hanging without any LogStart and LogEnd date and SAP is unable to discard them, these msgs stops CPI helper to display messages in popup ,using a timestamp from long back helpsso using date from 1900
+  var xhr = await makeCallPromiseXHR("GET", "/" + cpiData.urlExtension + "odata/api/v1/MessageProcessingLogs?$filter=IntegrationFlowName eq '" + iflowId + "' and LogStart gt datetime'1900-01-01T01:02:50' and Status ne 'DISCARDED'&$top=" + numberEntries + "&$format=json&$orderby=LogEnd desc", false, null, null, false, "", false)
+  
   if (xhr.readyState == 4 && sidebar.active) {
 
     var resp = null


### PR DESCRIPTION
No messages are displayed if there are dangling RETRY msgs from the past with no LogStart or LogEnd ie null
e.g Dangling msg as below:
![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/24839793/87a77f4e-e0d4-42fd-b224-d2356c74e3fc)
It stops all the messages from being displayed

Earlier a change was suggested and RETRY msgs were discarded but that impacted other tenants, to have no impact the code now uses  LogStart gt datetime'1900-01-01T01:02:50' which is from long past and will remove RETRY msgs with LogStart as null