### PR TITLE
Unlock Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ It is open source so feel free to check the source code.
 
 ## Changelog
 
+### 3.13.0
+
+- [Plugin] Unlock Plugin to unlock integration flows directly from design screen. Special thanks to Gregor Schütz from [AGILITA AG](https://www.agilita.ch/).
+
 ### 3.12.1
 
 - [Improvement] Better payload viewer & Update payload directly in trace Body panel. Special thanks to [Omkar Patel](https://github.com/incpi).

--- a/manifest.json
+++ b/manifest.json
@@ -55,6 +55,7 @@
         "/plugins/simplenotepad.js",
         "/plugins/reference.js",
         "/plugins/undeploy.js",
+        "/plugins/unlock.js",
         "/plugins/cpitransporter.js",
         "/plugins/figaf.js",
         "/plugins/OpenAIServices.js",

--- a/manifest.json_v3
+++ b/manifest.json_v3
@@ -35,6 +35,7 @@
         "/lib/semanticui/semantic.min.js",
         "/plugins/run.js",
         "/plugins/undeploy.js",
+        "/plugins/unlock.js",
         "/plugins/cpitransporter.js",
         "/plugins/figaf.js",
         "/plugins/OpenAIServices.js",

--- a/plugins/timeline.js
+++ b/plugins/timeline.js
@@ -6,7 +6,7 @@ var plugin = {
     author: "Gregor Schütz, AGILITA AG",
     website: "https://www.agilita.ch/",
     email: "gregor.schuetz@agilita.ch",
-    description: "Displays the timeline of a message.",
+    description: "<br><b>(Trace not needed)</b></br> Displays the timeline of a message.",
     settings: {
         "icon": { "type": "icon", "src": "/images/plugin_logos/AGILITAAG_Logo.jpg" }
     },
@@ -68,6 +68,8 @@ function createContent(data, pluginHelper) {
                 <th>Status</th>
                 <th>Start Date</th>
                 <th>Start Time</th>
+                <th>End Date</th>
+                <th>End Time</th>
             </tr>
         </thead>
         </tbody>`;
@@ -95,8 +97,10 @@ function createContent(data, pluginHelper) {
             statusColor = "blue";
         }
 
-        var date = JSON.parse(formatTimestamp(artifact.LogStart)).date;
-        var time = JSON.parse(formatTimestamp(artifact.LogStart)).time;
+        var startdate = JSON.parse(formatTimestamp(artifact.LogStart)).date;
+        var starttime = JSON.parse(formatTimestamp(artifact.LogStart)).time;
+        var enddate = JSON.parse(formatTimestamp(artifact.LogEnd)).date;
+        var endtime = JSON.parse(formatTimestamp(artifact.LogEnd)).time;
         var packageLink = `https://${pluginHelper.tenant}/${pluginHelper.urlExtension}shell/design/contentpackage/${artifact.IntegrationArtifact.PackageId}?section=ARTIFACTS`;
         // Displaying the currently viewed artifact differently than the connected artifacts
         // No link for currently viewed artifact (because we are already viewing it)
@@ -107,12 +111,14 @@ function createContent(data, pluginHelper) {
                 <td data-label="Nr." class="ui center aligned">${index + 1}.</td>
                 <td data-label="Integration Flow Name" ${artifact.IntegrationArtifact.Id != pluginHelper.integrationFlowId
                 ? `class="selectable"><a href="${link}" target="_blank">${artifact.IntegrationArtifact.Name}</a>`
-                : `class="selectable yellow">${artifact.IntegrationArtifact.Name} (currently viewing)`}
+                : `class="yellow">${artifact.IntegrationArtifact.Name} (currently viewing)`}
                 </td>
                 <td data-label="Integration Package" class="selectable"><a href="${packageLink}" target="_blank">${artifact.IntegrationArtifact.PackageName}</a></td>
                 <td data-label="Status">${artifact.Status}</td>
-                <td data-label="Start Date">${date}</td>
-                <td data-label="Start Time">${time}</td>
+                <td data-label="Start Date">${startdate}</td>
+                <td data-label="Start Time">${starttime}</td>
+                <td data-label="End Date">${enddate}</td>
+                <td data-label="End Time">${endtime}</td>
             </tr>`;
     });
 

--- a/plugins/unlock.js
+++ b/plugins/unlock.js
@@ -19,7 +19,7 @@ var plugin = {
             button.innerHTML = "unlock";
 
             //removes or rather deletes the lock on this artifact
-            button.onclick = async (x) => {
+            button.onclick = async () => {
                 //prepare unlock
                 const urlForResourceId = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks?$format=json`;
                 var dataOfDesigntimeLocks = JSON.parse(await makeCallPromise("GET", urlForResourceId, false)).d.results;

--- a/plugins/unlock.js
+++ b/plugins/unlock.js
@@ -1,7 +1,7 @@
 var plugin = {
     metadataVersion: "1.0.0",
     id: "unlock",
-    name: "Unlock Artifact",
+    name: "unlock plugin",
     version: "1.0.0",
     author: "Gregor Schütz, AGILITA AG",
     website: "https://www.agilita.ch/",

--- a/plugins/unlock.js
+++ b/plugins/unlock.js
@@ -31,9 +31,14 @@ var plugin = {
                 
                 //unlock artifact if locked
                 if(resourceId != undefined){ //undefined means it's not locked
-                    var urlForUnlock = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks(ResourceId='${resourceId}')`;
-                    await makeCallPromise("DELETE", urlForUnlock, false);
-                    showToast("The artifact has been unlocked");
+                    try{
+                        var urlForUnlock = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks(ResourceId='${resourceId}')`;
+                        await makeCallPromise("DELETE", urlForUnlock, false);
+                        showToast("The artifact has been unlocked", "", "success");
+                    }catch(exception){
+                        showToast("Could not unlock artifact", "", "error");
+                        console.log(exception);
+                    }
                 }else{
                     showToast("The artifact is not locked");
                 }

--- a/plugins/unlock.js
+++ b/plugins/unlock.js
@@ -24,15 +24,18 @@ var plugin = {
                 const urlForResourceId = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks?$format=json`;
                 var dataOfDesigntimeLocks = JSON.parse(await makeCallPromise("GET", urlForResourceId, false)).d.results;
                 
+                //get resourceid by matching the artifactid
                 var resourceId = dataOfDesigntimeLocks.find(function (a){
                     return a.ArtifactId === pluginHelper.currentArtifactId
                 })?.ResourceId;
                 
                 //unlock artifact if locked
                 if(resourceId != undefined){ //undefined means it's not locked
-                    location.reload(); //refresh is need because of issues when switching from one CPI tenant to another
                     var urlForUnlock = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks(ResourceId='${resourceId}')`;
                     await makeCallPromise("DELETE", urlForUnlock, false);
+                    showToast("The artifact has been unlocked");
+                }else{
+                    showToast("The artifact is not locked");
                 }
             }
 

--- a/plugins/unlock.js
+++ b/plugins/unlock.js
@@ -1,0 +1,46 @@
+var plugin = {
+    metadataVersion: "1.0.0",
+    id: "unlock",
+    name: "Unlock Artifact",
+    version: "1.0.0",
+    author: "Gregor Schütz, AGILITA AG",
+    website: "https://www.agilita.ch/",
+    email: "gregor.schuetz@agilita.ch",
+    description: "Adds an unlock button to the message sidebar.",
+    settings: {
+        "icon": { "type": "icon", "src": "/images/plugin_logos/AGILITAAG_Logo.jpg" }
+    },
+    messageSidebarContent: {
+        "static": true,
+        "onRender": (pluginHelper) => {
+            //prepare button
+            var div = document.createElement("div");
+            var button = document.createElement("button");
+            button.innerHTML = "unlock";
+
+            //removes or rather deletes the lock on this artifact
+            button.onclick = async (x) => {
+                //prepare unlock
+                const urlForResourceId = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks?$format=json`;
+                var dataOfDesigntimeLocks = JSON.parse(await makeCallPromise("GET", urlForResourceId, false)).d.results;
+                
+                var resourceId = dataOfDesigntimeLocks.find(function (a){
+                    return a.ArtifactId === pluginHelper.currentArtifactId
+                })?.ResourceId;
+                
+                //unlock artifact if locked
+                if(resourceId != undefined){ //undefined means it's not locked
+                    location.reload(); //refresh is need because of issues when switching from one CPI tenant to another
+                    var urlForUnlock = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks(ResourceId='${resourceId}')`;
+                    await makeCallPromise("DELETE", urlForUnlock, false);
+                }
+            }
+
+            //adds button
+            div.appendChild(button)
+            return div;
+        }
+    }
+};
+
+pluginList.push(plugin);

--- a/whatsNew/whatsNewLog.js
+++ b/whatsNew/whatsNewLog.js
@@ -6,30 +6,7 @@
 // ]
 const whats_new_log = [
     {
-        "header": "Improvement",
-        "description": "Better payload viewer. Special thanks to <a target='_blank' href='http://github.com/incpi'>Omkar Patel</a>"
-    },
-    {
-        "header": "Improvement",
-        "description": "Go live of <a target='_blank' href='https://dbeck121.github.io/CPI-Helper-Chrome-Extension'>Github Webpage</a>. Special thanks to <a target='_blank' href='http://github.com/incpi'>Omkar Patel</a>"
-    },
-    {
-        "header": "Bugfixes",
-        "description": "Shows Content Enricher now in Inline Trace"
-    },{
-        "header": "Bugfixes",
-        "description": "UI Icon are changed + UI Bugfixes"
-    },
-    {
-        "header": "Feature",
-        "description": "Regex/ find /replace featured added with Ctrl + F (find) in formatted payload(Trace body tab)."
-    },
-    {
-        "header": "Feature",
-        "description": "UI Icon changed, Resize Body from Content modifier,Regex/ find /replace featured added with Ctrl + F (find) in formatted payload(Trace body tab)."
-    },
-    {
-        "header": "Feature",
-        "description": "Once trace expired, no popup will be shown instead warning will be given."
+        "header": "Plugin",
+        "description": "Unlock Plugin to unlock integration flows directly from design screen. Special thanks to Gregor Schütz from <a target='_blank' href='https://www.agilita.ch/'>AGILITA AG</a>"
     }
 ]


### PR DESCRIPTION
**Description**
This little Plugin adds a button to the message sidebar and unlocks the viewed artifact when clicked.

**Steps**
When the button is clicked the following is executed:
1. We get all the locked artifacts with the CPI API -> /api/v1/IntegrationDesigntimeLocks (filtering seems to be ignored and we always get every locked artifact)
2. We find the resourceid of the locked artifact matching the artifactid of the api and pluginhelper
3. We delete the lock -> DELETE /api/v1/IntegrationDesigntimeLocks(ResourceId='resourceId')

**INFO**
Step 3 includes a toast message that is shown in both cases (locked or already unlocked)

**ISSUE**
When I tried this with a CPI on the Neo environment the response was 403 Forbidden. Seems to be related to the makeCallPromise function in Tools.