### PR TITLE
location of sidebar

### DIFF
--- a/css/contentScript.css
+++ b/css/contentScript.css
@@ -162,8 +162,8 @@ button.cpiHelper_sidebar_iconbutton span {
   position: fixed;
   z-index: 400;
   background: var(--cpi-background-color);
-  top: 120px;
-  right: 50px;
+  top: 150px;
+  right: 80px;
   width: fit-content;
   border: 0;
   border-radius: 10px;


### PR DESCRIPTION
To prepare for future SAP UI changes (already live on Neo), we should move the sidebar down (can already be done, no negative impact). Also I move it a bit to the left as it always covered the zoom and navigator buttons (rarely used by most, but was unclean nevertheless). 

More changes to come for color etc., see https://github.com/dbeck121/CPI-Helper-Chrome-Extension/issues/172.
