### PR TITLE
Color Issue Fix

### DIFF
--- a/css/contentScript.css
+++ b/css/contentScript.css
@@ -2,7 +2,7 @@
 :root {
   --cpi-custom-color: #ffffff;
   --cpi-background-color: #ffffff;
-  --button-active-color: #2185d0;
+  --button-active-color: #767676;
 }
 
 /* whats new */

--- a/css/contentScript.css
+++ b/css/contentScript.css
@@ -1,7 +1,8 @@
 /*root filter*/
 :root {
-  --cpi-custom-color: #2185d0;
-  --cpi-background-color: #fff;
+  --cpi-custom-color: #ffffff;
+  --cpi-background-color: #ffffff;
+  --button-active-color: #2185d0;
 }
 
 /* whats new */
@@ -76,12 +77,12 @@
 
 .cpiHelper button.cpiHelper_inlineInfo-active,
 .cpiHelper button.cpiHelper_plugin-active {
-  background: var(--cpi-custom-color);
-  color: var(--cpi-background-color);
+  background: var(--button-active-color);
+  color: #000;
 }
 
 .cpiHelper button:active {
-  background: var(--cpi-custom-color);
+  background: var(--button-active-color);
 }
 
 .cpiHelper button:focus {
@@ -187,7 +188,7 @@ button.cpiHelper_sidebar_iconbutton span {
   font-weight: bold;
   z-index: 10;
   background-color: var(--cpi-custom-color);
-  color:var(--cpi-background-color);
+  color: #000;
   box-sizing: border-box;
   border-radius: 5px 5px 0px 0px;
   display: flex;

--- a/css/contentScript.css
+++ b/css/contentScript.css
@@ -542,7 +542,7 @@ fieldset {
 
 .ui.modal.active>.header {
   background: var(--cpi-custom-color);
-  color: var(--cpi-background-color);
+  color: #000;
 }
 
 .ui.selection.dropdown .menu > .item {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -314,7 +314,7 @@ function addTenantSettings() {
     //reset color btn
     document.querySelector('#tenantSettings > div >div > button').addEventListener('click', () => {
         const tenantColor = document.querySelector('#colorSelect');
-        tenantColor.value = '#2185d0';
+        tenantColor.value = '#ffffff';
         tenantColor.dispatchEvent(new Event("change"));
     })
     //cozy-compact mode btn
@@ -519,6 +519,7 @@ function tenantIdentityChanges() {
                 tenantLog.value = hostData.loglevel = response.loglevel;
                 tenantCount.value = hostData.count = response.count
                 popupcolor.style.setProperty('--cpi-custom-color', hostData.color = response.color);
+                popupcolor.style.setProperty('--button-active-color', hostData.color = response.color);
             }
         });
 
@@ -552,6 +553,7 @@ function tenantIdentityChanges() {
             console.log(tenantColor.value)
             // set popup.html header
             popupcolor.style.setProperty('--cpi-custom-color', tenantColor.value);
+            popupcolor.style.setProperty('--button-active-color', tenantColor.value);
             chrome.tabs.sendMessage(tab.id, { save: hostData }, (response) => {
                 console.dir(response);
             })

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -1329,7 +1329,7 @@ var sidebar = {
       <span id='sidebar_modal_minimize' class='cpiHelper_closeButton_sidebar'>CPI Helper</span>
       <span id='sidebar_modal_close' data-sap-ui-icon-content="&#xe03e" class='cpiHelper_closeButton_sidebar sapUiIcon sapUiIconMirrorInRTL' style='font-size: 1.2rem;padding-inline-start: 1rem;font-family: SAP-icons'></span>
     </div>
-    <div id="outerFrame">
+    <div id="outerFrame" style="color: black;">
       <div>
         <div id="updatedText" class="contentText"></div>
         <div id="deploymentText" class="contentText">State: </div>

--- a/scripts/identify-tenant.js
+++ b/scripts/identify-tenant.js
@@ -179,6 +179,11 @@
       //sync header with popup header
       const root = document.querySelector(':root');
       root.style.setProperty('--cpi-custom-color', color);
+      if(color == "#ffffff"){
+        root.style.setProperty('--button-active-color', "#2185d0");
+      }else{
+        root.style.setProperty('--button-active-color', color);
+      }
 
       // Set the theme color meta tag
       let themeColorElement = document.querySelector("meta[name='theme-color']");

--- a/scripts/identify-tenant.js
+++ b/scripts/identify-tenant.js
@@ -180,7 +180,7 @@
       const root = document.querySelector(':root');
       root.style.setProperty('--cpi-custom-color', color);
       if(color == "#ffffff"){
-        root.style.setProperty('--button-active-color', "#2185d0");
+        root.style.setProperty('--button-active-color', "#767676");
       }else{
         root.style.setProperty('--button-active-color', color);
       }


### PR DESCRIPTION
- Fixes color issues especially for users who don't have any tenant color set (e.g. if CPI Helper was freshly installed)
- The default/reset color is set to white so it matches with what the header bar of the new CPI UI
- Tenant Color selection works as usual. I just generally changed the text color to black since the default background color is white
- The default background color of buttons is lightblue if no tenant color was set
- What's New Popup Header and Info Popup Header have now black text color and are visible if no tenant color was set

![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/77123831/8fee5ba5-82bc-4876-b23f-066dd43d115e)