### PR TITLE
Lock Details and Confirmation Step

### DIFF
--- a/plugins/unlock.js
+++ b/plugins/unlock.js
@@ -30,7 +30,7 @@ var plugin = {
                 //unlock artifact if locked
                 if(lock?.ResourceId != undefined){ //undefined means it's not locked
 
-                    //prepare coloring
+                    //calculate lock duration
                     const match = lock.CreatedAt.match(/\/Date\((\d+)\)\//);
                     const timeInMillis = parseInt(match[1], 10);
                     const currentTime = Date.now();
@@ -41,6 +41,19 @@ var plugin = {
                     const remainingHours = Math.floor(diffInHours % 24);
                     const remainingMinutes = Math.floor(diffInMinutes % 60);
 
+                    //prepare lock duration text
+                    var lockDurationText = "This artifact was locked ";
+                    if(diffInDays > 0){
+                        lockDurationText += `${diffInDays}d ${remainingHours}h ${remainingMinutes}min ago.`;
+                    } else if(remainingHours > 0){
+                        lockDurationText += `${remainingHours}h ${remainingMinutes}min ago.`;
+                    } else if(remainingMinutes > 0){
+                        lockDurationText += `${remainingMinutes}min ago.`;
+                    } else {
+                        lockDurationText += `less than a minute ago.`;
+                    }
+
+                    //map status color
                     var statusColor;
                     if (diffInHours >= 12) {
                         statusColor = "green";
@@ -53,34 +66,38 @@ var plugin = {
                     }
 
                     var info = `
-                    <div class="ui list">
-                        <div class="item">
-                            <div class="content">
-                                <a class="header">Integration Flow Name</a>
-                                <div class="description">${lock.ArtifactName}</div>
+                    <div class="ui large list">
+                                <div class="item">
+                                    <div class="content">
+                                        <a class="header">Integration Flow Name</a>
+                                        <div class="description">${lock.ArtifactName}</div>
+                                    </div>
+                                </div>
+                                <div class="item">
+                                    <div class="content">
+                                        <a class="header">Integration Package</a>
+                                        <div class="description">${lock.PackageName}</div>
+                                    </div>
+                                </div>
+                                <div class="item">
+                                    <div class="content">
+                                        <a class="header">Locked by</a>
+                                        <div class="description">${lock.CreatedBy}</div>
+                                    </div>
+                                </div>
+                                <div class="item">
+                                    <div class="content">
+                                        <a class="header">Locked since</a>
+                                        <div class="description">${formatDate(lock.CreatedAt)}</div>
+                                    </div>
+                                </div>
+                            </div>
+                    <div class="ui grid">
+                        <div class="one column centered row">
+                            <div class="ui ${statusColor} tiny center aligned compact message">
+                                <p><i class="info icon"></i> ${lockDurationText}</p>
                             </div>
                         </div>
-                        <div class="item">
-                            <div class="content">
-                                <a class="header">Integration Package</a>
-                                <div class="description">${lock.PackageName}</div>
-                            </div>
-                        </div>
-                        <div class="item">
-                            <div class="content">
-                                <a class="header">Locked by</a>
-                                <div class="description">${lock.CreatedBy}</div>
-                            </div>
-                        </div>
-                        <div class="item">
-                            <div class="content">
-                                <a class="header">Locked since</a>
-                                <div class="description">${formatDate(lock.CreatedAt)}</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="ui mini ${statusColor} compact message">
-                        <p>locked ${diffInDays}d ${remainingHours}h ${remainingMinutes}min ago</p>
                     </div>`;
 
                     $.modal('confirm', 'Lock Details', info, async function(choice){

--- a/plugins/unlock.js
+++ b/plugins/unlock.js
@@ -67,31 +67,31 @@ var plugin = {
 
                     var info = `
                     <div class="ui large list">
-                                <div class="item">
-                                    <div class="content">
-                                        <a class="header">Integration Flow Name</a>
-                                        <div class="description">${lock.ArtifactName}</div>
-                                    </div>
-                                </div>
-                                <div class="item">
-                                    <div class="content">
-                                        <a class="header">Integration Package</a>
-                                        <div class="description">${lock.PackageName}</div>
-                                    </div>
-                                </div>
-                                <div class="item">
-                                    <div class="content">
-                                        <a class="header">Locked by</a>
-                                        <div class="description">${lock.CreatedBy}</div>
-                                    </div>
-                                </div>
-                                <div class="item">
-                                    <div class="content">
-                                        <a class="header">Locked since</a>
-                                        <div class="description">${formatDate(lock.CreatedAt)}</div>
-                                    </div>
-                                </div>
+                        <div class="item">
+                            <div class="content">
+                                <a class="header">Integration Flow Name</a>
+                                <div class="description">${lock.ArtifactName}</div>
                             </div>
+                        </div>
+                        <div class="item">
+                            <div class="content">
+                                <a class="header">Integration Package</a>
+                                <div class="description">${lock.PackageName}</div>
+                            </div>
+                        </div>
+                        <div class="item">
+                            <div class="content">
+                                <a class="header">Locked by</a>
+                                <div class="description">${lock.CreatedBy}</div>
+                            </div>
+                        </div>
+                        <div class="item">
+                            <div class="content">
+                                <a class="header">Locked since</a>
+                                <div class="description">${formatDate(lock.CreatedAt)}</div>
+                            </div>
+                        </div>
+                    </div>
                     <div class="ui grid">
                         <div class="one column centered row">
                             <div class="ui ${statusColor} tiny center aligned compact message">

--- a/plugins/unlock.js
+++ b/plugins/unlock.js
@@ -21,22 +21,101 @@ var plugin = {
                 //prepare unlock
                 const urlForResourceId = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks?$format=json`;
                 var dataOfDesigntimeLocks = JSON.parse(await makeCallPromise("GET", urlForResourceId, false)).d.results;
-                
+
                 //get resourceid by matching the artifactid
-                var resourceId = dataOfDesigntimeLocks.find(function (a){
+                var lock = dataOfDesigntimeLocks.find(function (a){
                     return a.ArtifactId === pluginHelper.currentArtifactId
-                })?.ResourceId;
+                });
                 
                 //unlock artifact if locked
-                if(resourceId != undefined){ //undefined means it's not locked
-                    try{
-                        var urlForUnlock = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks(ResourceId='${resourceId}')`;
-                        await makeCallPromise("DELETE", urlForUnlock, false, null, null, true);
-                        showToast("The artifact has been unlocked", "", "success");
-                    }catch(exception){
-                        showToast("Could not unlock artifact", "", "error");
-                        console.log(exception);
+                if(lock?.ResourceId != undefined){ //undefined means it's not locked
+                    //prepare lock info
+                    var popupContent = document.createElement("div");
+                    var confirmButton = document.createElement("button");
+                    confirmButton.className = "mini ui red button";
+                    confirmButton.innerHTML = "Confirm";
+                    var info = document.createElement("div");
+                    info.className = "ui one column grid";
+
+                    //prepare coloring
+                    const match = lock.CreatedAt.match(/\/Date\((\d+)\)\//);
+                    const timeInMillis = parseInt(match[1], 10);
+                    const currentTime = Date.now();
+                    const diffInMillis = currentTime - timeInMillis;
+                    const diffInMinutes = diffInMillis / (1000 * 60);
+                    const diffInHours = Math.floor(diffInMinutes / 60);
+                    const remainingMinutes = Math.floor(diffInMinutes % 60);
+                    
+                    var statusColor;
+                    if (diffInHours >= 24) {
+                        statusColor = "green";
+                    } else if (diffInHours >= 12) {
+                        statusColor = "yellow";
+                    } else if (diffInHours >= 6) {
+                        statusColor = "orange";
+                    } else if (diffInHours >= 3) {
+                        statusColor = "red";
                     }
+
+                    info.innerHTML = `
+                    <div class="column">
+                        <div class="ui compact raised segment">
+                            <a class="ui blue ribbon label">Overview</a>
+                            <span>Lock Details</span><div class="ui left pointing ${statusColor} basic label">locked ${diffInHours}h ${remainingMinutes}min ago</div>
+                            <div class="ui list">
+                                <div class="item">
+                                    <div class="content">
+                                        <a class="header">Integration Flow Name</a>
+                                        <div class="description">${lock.ArtifactName}</div>
+                                    </div>
+                                </div>
+                                <div class="item">
+                                    <div class="content">
+                                        <a class="header">Integration Package</a>
+                                        <div class="description">${lock.PackageName}</div>
+                                    </div>
+                                </div>
+                                <div class="item">
+                                    <div class="content">
+                                        <a class="header">Locked by</a>
+                                        <div class="description">${lock.CreatedBy}</div>
+                                    </div>
+                                </div>
+                                <div class="item">
+                                    <div class="content">
+                                        <a class="header">Locked since</a>
+                                        <div class="description">${formatDate(lock.CreatedAt)}</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>`;
+
+                    confirmButton.addEventListener("click", async () => {
+                        try{
+                            dataOfDesigntimeLocks = JSON.parse(await makeCallPromise("GET", urlForResourceId, false)).d.results;
+
+                            //get resourceid by matching the artifactid
+                            var lock = dataOfDesigntimeLocks.find(function (a){
+                                return a.ArtifactId === pluginHelper.currentArtifactId
+                            });
+
+                            //unlock artifact if locked
+                            if(lock?.ResourceId != undefined){
+                                var urlForUnlock = `/${pluginHelper.urlExtension}odata/api/v1/IntegrationDesigntimeLocks(ResourceId='${lock?.ResourceId}')`;
+                                await makeCallPromise("DELETE", urlForUnlock, false, null, null, true);
+                                showToast("The artifact has been unlocked", "", "success");
+                            }else{
+                                showToast("The artifact is not locked");
+                            }
+                        }catch(exception){
+                            showToast("Could not unlock artifact", "", "error");
+                        }
+                    });
+
+                    popupContent.appendChild(info);
+                    popupContent.appendChild(confirmButton);
+                    pluginHelper.functions.popup(popupContent, "Unlock Plugin");
                 }else{
                     showToast("The artifact is not locked");
                 }
@@ -46,5 +125,41 @@ var plugin = {
         }
     }
 };
+
+//returns formatted date & time
+function formatDate(timestamp) {
+    const matches = timestamp.match(/\/Date\((\d+)\)\//);
+
+    const date = new Date(parseInt(matches[1], 10));
+
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    const hours = date.getHours().toString().padStart(2, '0');
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+    const seconds = date.getSeconds().toString().padStart(2, '0');
+    const milliseconds = date.getMilliseconds().toString().padStart(3, '0');
+
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}`;
+}
+
+//returns string based on time diffrence
+function getLockStatus(timestamp) {
+    const match = timestamp.match(/\/Date\((\d+)\)\//);
+    const timeInMillis = parseInt(match[1], 10);
+    const currentTime = Date.now();
+    const diffInMillis = currentTime - timeInMillis;
+    const diffInHours = diffInMillis / (1000 * 60 * 60);
+
+    if (diffInHours >= 24) {
+        return "green";
+    } else if (diffInHours >= 12) {
+        return "yellow";
+    } else if (diffInHours >= 6) {
+        return "orange";
+    } else if (diffInHours >= 3) {
+        return "red";
+    }
+}
 
 pluginList.push(plugin);


### PR DESCRIPTION
This adds a sort of "confirmation step" where before you can unlock the iFlow, it will prompt you with a popup telling you the details about who locked it and when.

Coloring of the message is based off of how long the lock exists:

- up to 3 hours = red
- up to 6 hours = orange
- up to 12 hours = yellow
- over 12 hours = green

_Displayed are up to days but not seconds. If there are no minutes it says "less than a minute"._

![image](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/assets/77123831/6a96b864-94d1-4bbe-861d-06a856e7ada4)