### PR TITLE
3.7.1: Fix for the Trace activation issue that sometimes kills Iflows

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "SAP CPI Helper",
   "short_name": "CPI Helper",
 
-  "version": "3.17.0",
+  "version": "3.17.1",
 
   "description": "Extends the SAP Cloud Platform Integration with some useful features to improve usability.",
   "author": "Dominic Beckbauer",

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -975,10 +975,7 @@ async function buildButtonBar() {
 
 //Collect Infos to Iflow
 async function getIflowInfo(callback, silent = false) {
-  // count list of runtime locations to check if we have edge cell(s)
-  const edgeMenuEntry = document.querySelectorAll("#admincockpit");
-  cpiData.isEdge = edgeMenuEntry != undefined;
-
+  // first we check if we have an Edge cell connected to the tenant
   return makeCallPromise("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.srv.web.cf.RuntimeLocationListCommand", false, null, null, null, null, !silent)
     .then((response) => {
       response = new XmlToJson().parse(response)["com.sap.it.op.srv.web.cf.RuntimeLocationListResponse"];
@@ -989,6 +986,7 @@ async function getIflowInfo(callback, silent = false) {
       return makeCallPromise("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListCommand", false, null, null, null, null, !silent);
     })
     .then((response) => {
+      // load all non-Edge iflows and search the currently opened Iflow
       response = new XmlToJson().parse(response)["com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListResponse"];
       var resp = response.artifactInformations;
 

--- a/whatsNew/whatsNewLog.js
+++ b/whatsNew/whatsNewLog.js
@@ -1,16 +1,4 @@
 // template = - [header :your header as HTML] [description": "description goes here as HTML] ,... //multiple
 const whats_new_log = `   
-- [Improvement] UI Bugfixes (Dark-mode Darker color for trace, Trace-inline tool editor detect mode you selected by default).
-- [Improvement] XML declaration preserved by code beautify function.
-- [Plugin] WHINT Interface Documentation Plugin - Update v1.2
-- [Plugin] Performance stats plugin has better color for dark mode.
-- [Plugin] Settings Pane Resizer plugin opens settings pane on page load even if Pause mode is active.
-- [Feature] Color mode detected a theme and applied by default (in case of dark mode).
-- [Feature] More compatibale with DARK CPI extension dark mode.
-- [Feature] Position of popup is now state aware.
-- [Feature] Body download option now with proper extension.
-- [Feature] Text wrap option and theme of editor has clear information.
-- [Feature] General UI Bugfix & backend global element to organize. [Read more here with snapshot note](https://github.com/dbeck121/CPI-Helper-Chrome-Extension/pull/194). Special thanks to [Omkar](https://github.com/incpi).
-- [Fix] Solved problem with activating trace in situations with multiple runtimes.
-- [Fix] Solved problem with Firefox
+- [Fix] Solved problem with activating trace (on non-Edge Cell and Edge Cell tenants).
 `;


### PR DESCRIPTION
Explanation what I have changed: 
Method getIflowInfo():
1. first we check if we have an Edge cell connected to the tenant. For this I use the internal API RuntimeLocationListCommand . 
2. then I call IntegrationComponentsListCommand without locationID to retrieve Iflows deployed normally (not on edge), regardless if we have an edge cell or not. 
3. if the currently opened iflow is not part of the retrieved list of artifacts AND we have an Edge cell on the tenant, I call IntegrationComponentsListCommand again, this time including the location ID. 
4. If the iflow was deployed on the Edge, it will be present in this second response.

The cpiData properties runtimeLocationId and isEdge are set in this method. 

Method setLogLevel(): 
- if cpiData.runtimeLocationId && cpiData.isEdge --> set the trace including the paramater runtimeLocationId. Otherwise, if the Tenant has no Edge cell, the parameter must not be passed as this causes the bug with improperly set Trace (not visible in Monitoring, and in some cases blocks the Trace completely on this Iflow).

@dbeck121  I hope this solves the issue that some users are facing, and is not causing any other problems. Without knowing what SAP changed and how the internal APIs work, it's just guessing...