### PR TITLE
Fix Timeline plugin to support correlation IDs containing special characters

### DIFF
--- a/plugins/timeline.js
+++ b/plugins/timeline.js
@@ -22,7 +22,7 @@ var plugin = {
       // Get data for table
       // Order by LogStart so we know in what order it started
       const urlForPathData = `/${pluginHelper.urlExtension}odata/api/v1/MessageProcessingLogs?$format=json&$filter=CorrelationId eq '${dataOfCurrentMessage[0].CorrelationId}'&$orderby=LogStart`;
-      var dataForTable = JSON.parse(await makeCallPromise("GET", urlForPathData, false)).d.results;
+      var dataForTable = JSON.parse(await makeCallPromise("GET", encodeURI(urlForPathData), false)).d.results;
 
       // Popup
       var popupContent = document.createElement("div");


### PR DESCRIPTION
Figaf creates correlation IDs with a pipe symbol in it. This makes the API calls fail when using the Timeline plugin. 
This is a fix for it. 