### PR TITLE
perf(cf): replace bulk API with OData for load reduction

### DIFF
--- a/common/tools.js
+++ b/common/tools.js
@@ -116,6 +116,10 @@ class SimpleCache {
     return cachedItem.data;
   }
 
+  delete(id) {
+    this.cache.delete(id);
+  }
+
   // Method to clean up expired entries
   cleanUp() {
     const currentTime = Date.now();
@@ -257,7 +261,9 @@ async function makeCallPromiseV2(method, url, useCache, accept, payload, include
     return cache;
   }
 
-  var xhr = await makeCallPromiseXHR(method, url, accept, payload, includeXcsrf, contentType, (showInfo = true)).catch((error) => {
+  var xhr = await makeCallPromiseXHR(method, url, accept, payload, includeXcsrf, contentType, showInfo).catch((error) => {
+    httpCache.delete(method + url); // In case of error, ensure that the cache is cleared for this entry
+
     return { successful: false, status: error.status, statusText: error.statusText, responseText: error.responseText };
   });
 
@@ -619,6 +625,7 @@ function getStatusColorCode(status, isDarkMode = !$("html").hasClass("sapUiTheme
     ABANDONED: isDarkMode ? "#788fa6" : "#a9b4be",
     STORED: isDarkMode ? "#30914c" : "#6dad1f",
     DEPLOYED: isDarkMode ? "#30914c" : "#6dad1f",
+    STARTED: isDarkMode ? "#30914c" : "#6dad1f",
     COMPLETED: isDarkMode ? "#30914c" : "#6dad1f",
     default: isDarkMode ? "#788fa6" : "#a9b4be",
   };

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -1151,7 +1151,7 @@ async function getIflowInfoExtended(silent = true) {
         null,
         null,
         null,
-        silent
+        !silent
       );
 
       if (!detailResp.successful) {

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -824,20 +824,45 @@ async function getIflowInfoCf(callback, silent = false, cache = true) {
     runtimeLocationWithActiveIFlow = [];
     for (const loc of cpiData.runtimeLocations) {
       try {
-        const locIdParam = "?runtimeLocationId=" + loc.id;
-        const resp = await makeCallPromiseV2("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListCommand" + locIdParam, cacheValue, null, null, null, null, silent);
+        const symbolicName = cpiData.integrationFlowId;
+        const resp = await makeCallPromiseV2(
+          "GET",
+          `/api/v1/IntegrationRuntimeArtifacts('${symbolicName}')?$format=json&$select=Id,Version,Status,DeployedOn,DeployedBy,SemanticState,TenantId`,
+          cacheValue,
+          "application/json",
+          null,
+          null,
+          null,
+          silent
+        );
 
         if (!resp.successful) {
-          log.warn("Error fetching integration components for runtime location " + loc.id + ": " + resp.message);
+          // 404 means IFlow not deployed on this runtime location (expected)
+          if (resp.status === 404) {
+            log.debug(`IFlow ${symbolicName} not found on runtime location ${loc.id}`);
+            continue;
+          }
+          // Other errors (500, network issues, etc.)
+          log.warn(`Error fetching artifact for runtime location ${loc.id}: ${resp.statusText}`);
           continue;
         }
 
-        const respJson = new XmlToJson().parse(resp.responseText)["com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListResponse"];
-        const artifact = Array.isArray(respJson.artifactInformations)
-          ? respJson.artifactInformations.find((e) => e.symbolicName == cpiData.integrationFlowId)
-          : respJson.artifactInformations?.symbolicName == cpiData.integrationFlowId
-            ? respJson.artifactInformations
-            : null;
+        const respJson = JSON.parse(resp.responseText);
+        const artifact = respJson.d;  // OData v4 wraps data in 'd' property
+
+        // Map OData field names to plugin's expected structure
+        if (artifact) {
+          artifact.symbolicName = symbolicName;
+          artifact.id = artifact.Id;
+          artifact.version = artifact.Version;
+          artifact.deployState = artifact.Status;
+          artifact.deployedOn = artifact.DeployedOn;
+          artifact.deployedBy = artifact.DeployedBy;
+          artifact.semanticState = artifact.SemanticState;
+          artifact.tenantId = artifact.TenantId;
+          artifact.name = artifact.Name || symbolicName;  // Fallback to symbolicName if Name not present
+        }
+
         if (artifact) {
           // collect information about current tenant and artifact if runtime location matches the selected one. this is needed to avoid another call to get the artifact information later, because we already have it here
           if (cpiData.runtimeLocationId && loc.id == cpiData.runtimeLocationId) {

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -827,7 +827,7 @@ async function getIflowInfoCf(callback, silent = false, cache = true) {
     for (const loc of cpiData.runtimeLocations) {
       try {
         const symbolicName = cpiData.integrationFlowId;
-        const resp = await makeCallPromiseV2("GET", `/api/v1/IntegrationRuntimeArtifacts('${symbolicName}')?$format=json`, cacheValue, "application/json", null, null, null, silent);
+        const resp = await makeCallPromiseV2("GET", `/api/v1/IntegrationRuntimeArtifacts('${symbolicName}')?$format=json`, cacheValue, "application/json", null, null, null, !silent);
 
         if (!resp.successful) {
           // 404 means IFlow not deployed on this runtime location (expected)

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -824,20 +824,43 @@ async function getIflowInfoCf(callback, silent = false, cache = true) {
     runtimeLocationWithActiveIFlow = [];
     for (const loc of cpiData.runtimeLocations) {
       try {
-        const locIdParam = "?runtimeLocationId=" + loc.id;
-        const resp = await makeCallPromiseV2("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListCommand" + locIdParam, cacheValue, null, null, null, null, silent);
+        const symbolicName = cpiData.integrationFlowId;
+        const resp = await makeCallPromiseV2(
+          "GET",
+          `/api/v1/IntegrationRuntimeArtifacts('${symbolicName}')?$format=json`,
+          cacheValue,
+          "application/json",
+          null,
+          null,
+          null,
+          silent
+        );
 
         if (!resp.successful) {
-          log.warn("Error fetching integration components for runtime location " + loc.id + ": " + resp.message);
+          // 404 means IFlow not deployed on this runtime location (expected)
+          if (resp.status === 404) {
+            log.debug(`IFlow ${symbolicName} not found on runtime location ${loc.id}`);
+            continue;
+          }
+          // Other errors (500, network issues, etc.)
+          log.warn(`Error fetching artifact for runtime location ${loc.id}: ${resp.statusText}`);
           continue;
         }
 
-        const respJson = new XmlToJson().parse(resp.responseText)["com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListResponse"];
-        const artifact = Array.isArray(respJson.artifactInformations)
-          ? respJson.artifactInformations.find((e) => e.symbolicName == cpiData.integrationFlowId)
-          : respJson.artifactInformations?.symbolicName == cpiData.integrationFlowId
-            ? respJson.artifactInformations
-            : null;
+        const respJson = JSON.parse(resp.responseText);
+        const artifact = respJson.d;  // OData v4 wraps data in 'd' property
+
+        // Map OData field names to plugin's expected structure
+        if (artifact) {
+          artifact.symbolicName = symbolicName;
+          artifact.id = artifact.Id;
+          artifact.version = artifact.Version;
+          artifact.deployState = artifact.Status;
+          artifact.deployedOn = artifact.DeployedOn;
+          artifact.deployedBy = artifact.DeployedBy;
+          artifact.name = artifact.Name || symbolicName;  // Fallback to symbolicName if Name not present
+        }
+
         if (artifact) {
           // collect information about current tenant and artifact if runtime location matches the selected one. this is needed to avoid another call to get the artifact information later, because we already have it here
           if (cpiData.runtimeLocationId && loc.id == cpiData.runtimeLocationId) {

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -398,9 +398,11 @@ async function setLogLevel(logLevel, iflowId) {
 }
 
 //undeploy IFlow via API call
-function undeploy(tenant = null, artifactId = null) {
+async function undeploy(tenant = null, artifactId = null) {
+  //to get tenant and artifactid.
+  await getIflowInfoExtended();
   tenant ??= cpiData.tenantId;
-  artifactId ??= cpiData.flowData.artifactInformation.id;
+  artifactId ??= cpiData.artifactUuid;
   edgeExtension = cpiData.runtimeLocationId != "cloudintegration" ? `&runtimeLocationId=${cpiData.runtimeLocationId}` : "";
   makeCallPromise(
     "POST",
@@ -825,16 +827,7 @@ async function getIflowInfoCf(callback, silent = false, cache = true) {
     for (const loc of cpiData.runtimeLocations) {
       try {
         const symbolicName = cpiData.integrationFlowId;
-        const resp = await makeCallPromiseV2(
-          "GET",
-          `/api/v1/IntegrationRuntimeArtifacts('${symbolicName}')?$format=json&$select=Id,Version,Status,DeployedOn,DeployedBy,SemanticState,TenantId`,
-          cacheValue,
-          "application/json",
-          null,
-          null,
-          null,
-          silent
-        );
+        const resp = await makeCallPromiseV2("GET", `/api/v1/IntegrationRuntimeArtifacts('${symbolicName}')?$format=json&$select=Id,Version,Status,DeployedOn,DeployedBy`, cacheValue, "application/json", null, null, null, !silent);
 
         if (!resp.successful) {
           // 404 means IFlow not deployed on this runtime location (expected)
@@ -848,7 +841,7 @@ async function getIflowInfoCf(callback, silent = false, cache = true) {
         }
 
         const respJson = JSON.parse(resp.responseText);
-        const artifact = respJson.d;  // OData v4 wraps data in 'd' property
+        const artifact = respJson.d; // OData v4 wraps data in 'd' property
 
         // Map OData field names to plugin's expected structure
         if (artifact) {
@@ -860,13 +853,12 @@ async function getIflowInfoCf(callback, silent = false, cache = true) {
           artifact.deployedBy = artifact.DeployedBy;
           artifact.semanticState = artifact.SemanticState;
           artifact.tenantId = artifact.TenantId;
-          artifact.name = artifact.Name || symbolicName;  // Fallback to symbolicName if Name not present
+          artifact.name = artifact.Name || symbolicName; // Fallback to symbolicName if Name not present
         }
 
         if (artifact) {
           // collect information about current tenant and artifact if runtime location matches the selected one. this is needed to avoid another call to get the artifact information later, because we already have it here
           if (cpiData.runtimeLocationId && loc.id == cpiData.runtimeLocationId) {
-            cpiData.tenantId = artifact.tenantId || null;
             cpiData.flowData.artifactInformation.lastUpdate = new Date().toISOString();
             cpiData.flowData.artifactInformation.artifactId = artifact.id || null;
             cpiData.flowData.artifactInformation.version = artifact.version || null;
@@ -1057,13 +1049,105 @@ async function setRuntimeLocation(location, silent = false) {
 }
 
 async function getIflowInfoExtended(silent = true) {
-  runtimeLocationWithActiveIFlowTemp = [];
+  id = null;
+  if (cpiData.cpiPlatform == "neo") {
+    cpiData.flowData.artifactInformation?.id;
+  }
+
+  if (cpiData.cpiPlatform == "cf") {
+    //we do this to get tenant and artifact uuid
+
+    runtimeLocationWithActiveIFlowTemp = [];
+
+    try {
+      //Get Runtime Locations
+      const runtimeLocResp = await makeCallPromiseV2("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.srv.web.cf.RuntimeLocationListCommand", null, null, null, null, null, silent);
+
+      if (!runtimeLocResp.successful) {
+        throw "Error fetching runtime locations: " + runtimeLocResp.message;
+        return false;
+      }
+
+      const runtimeLocJson = new XmlToJson().parse(runtimeLocResp.responseText)["com.sap.it.op.srv.web.cf.RuntimeLocationListResponse"];
+
+      //collect list of runtime locations
+      if (runtimeLocJson.runtimeLocations?.length) {
+        cpiData.runtimeLocations = runtimeLocJson.runtimeLocations.map((loc) => {
+          return {
+            id: loc.id,
+            state: loc.state,
+            type: loc.type,
+            typeId: loc.typeId,
+          };
+        });
+      } else {
+        cpiData.runtimeLocations = [{ id: runtimeLocJson.runtimeLocations.id, state: runtimeLocJson.runtimeLocations.state, type: runtimeLocJson.runtimeLocations.type, typeId: runtimeLocJson.runtimeLocations.typeId }];
+      }
+
+      // filter for active runtime locations
+      cpiData.runtimeLocations = cpiData.runtimeLocations.filter((loc) => loc.state.toUpperCase() == "ACTIVE");
+
+      if (cpiData.runtimeLocations.length == 0) {
+        throw "No active runtime locations found. Please check your environment.";
+      }
+
+      //iterate all runtime locations to find the ones that have active iflows
+      if (!cpiData.runtimeLocationWithActiveIFlow || cpiData.runtimeLocationWithActiveIFlow.length == 0) {
+      } else {
+        cpiData.runtimeLocationWithActiveIFlow = [];
+      }
+
+      runtimeLocationWithActiveIFlow = [];
+      for (const loc of cpiData.runtimeLocations) {
+        try {
+          const locIdParam = "?runtimeLocationId=" + loc.id;
+          const resp = await makeCallPromiseV2("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListCommand" + locIdParam, null, null, null, null, null, silent);
+
+          if (!resp.successful) {
+            log.warn("Error fetching integration components for runtime location " + loc.id + ": " + resp.message);
+            continue;
+          }
+
+          const respJson = new XmlToJson().parse(resp.responseText)["com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListResponse"];
+          const artifact = Array.isArray(respJson.artifactInformations)
+            ? respJson.artifactInformations.find((e) => e.symbolicName == cpiData.integrationFlowId)
+            : respJson.artifactInformations?.symbolicName == cpiData.integrationFlowId
+              ? respJson.artifactInformations
+              : null;
+          if (artifact) {
+            // collect information about current tenant and artifact if runtime location matches the selected one. this is needed to avoid another call to get the artifact information later, because we already have it here
+            if (cpiData.runtimeLocationId && loc.id == cpiData.runtimeLocationId) {
+              cpiData.tenantId = artifact.tenantId || null;
+              id = artifact.id || null;
+            }
+
+            runtimeLocationWithActiveIFlow.push({
+              id: loc.id,
+              state: loc.state,
+              type: loc.type,
+              typeId: loc.typeId,
+              artifact: artifact,
+            });
+          }
+        } catch (locError) {
+          log.warn("Error fetching runtime location " + loc.id + ": ", locError);
+          continue;
+        }
+      }
+    } catch (error) {
+      log.error("Error getting Iflow Info: ", error);
+      if (!silent) showToast("Error: " + JSON.stringify(error));
+    }
+  }
+
+  cpiData.artifactUuid = id;
+
   for (const loc of cpiData.runtimeLocations) {
     try {
       // 4. Detaildaten holen
       const detailResp = await makeCallPromiseV2(
         "GET",
-        "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentDetailCommand?artifactId=" + cpiData.flowData.artifactInformation?.id + "&runtimeLocationId=" + loc.id,
+        "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentDetailCommand?artifactId=" + id + "&runtimeLocationId=" + loc.id,
         null,
         "application/json",
         null,


### PR DESCRIPTION
CPI helper plugin's auto refresh is calling a bulk API that returns ALL 100+ artifacts every 15-90 seconds, causing significant backend load

Problem : 
https://github.com/dbeck121/CPI-Helper-Chrome-Extension/blob/02ba3f6/scripts/contentScript.js#L828 

—> it returns ALL artifacts and then filters client-side
GET /Operations/.../IntegrationComponentsListCommand
const artifact = allArtifacts.find(e => e.symbolicName == cpiData.integrationFlowId);


check if we can switch to our data api that returns only the artifact that really needed:

GET /api/v1/IntegrationRuntimeArtifacts('${symbolicName}')?$select=Id,Version,Status&$format=json
—> Returns JSON: { d: { Id: "...", Version: "1.0", Status: "DEPLOYED" } }