### PR TITLE
feat: add xsltDebugX plugin and improve groovyDebugX

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -71,6 +71,7 @@
         "/plugins/timeline.js",
         "/plugins/traceModifer.js",
         "/plugins/groovyDebugger.js",
+        "/plugins/xsltDebugX.js",
         "/plugins/removeApacheUpdateMessage.js",
         "/plugins/messageidlogs.js",
         "/plugins/connectivityCredentialsManager.js",

--- a/plugins/groovyDebugger.js
+++ b/plugins/groovyDebugger.js
@@ -55,25 +55,25 @@ if (!window.groovyDebugSendToIDE) {
         <div class="ui form">
           <div class="grouped fields">
             <div class="field">
-              <div class="ui checkbox ${prefs.body ? "checked" : ""}" id="transfer-body">
+              <div class="ui toggle checkbox" id="transfer-body">
                 <input type="checkbox" name="transfer-body" ${prefs.body ? "checked" : ""}>
                 <label>Message Body <em>(may contain sensitive data)</em></label>
               </div>
             </div>
             <div class="field">
-              <div class="ui checkbox ${prefs.script ? "checked" : ""}" id="transfer-script">
+              <div class="ui toggle checkbox" id="transfer-script">
                 <input type="checkbox" name="transfer-script" ${prefs.script ? "checked" : ""}>
                 <label>Groovy Script <em>(source code)</em></label>
               </div>
             </div>
             <div class="field">
-              <div class="ui checkbox ${prefs.properties ? "checked" : ""}" id="transfer-properties">
+              <div class="ui toggle checkbox" id="transfer-properties">
                 <input type="checkbox" name="transfer-properties" ${prefs.properties ? "checked" : ""}>
                 <label>Properties <em>(may contain configuration data)</em></label>
               </div>
             </div>
             <div class="field">
-              <div class="ui checkbox ${prefs.headers ? "checked" : ""}" id="transfer-headers">
+              <div class="ui toggle checkbox" id="transfer-headers">
                 <input type="checkbox" name="transfer-headers" ${prefs.headers ? "checked" : ""}>
                 <label>Headers <em>(may contain security & metadata)</em></label>
               </div>
@@ -103,9 +103,8 @@ if (!window.groovyDebugSendToIDE) {
           continueBtn.toggleClass("disabled", !anyChecked).prop("disabled", !anyChecked);
         };
 
-        $("#cpiHelper_semanticui_modal .ui.checkbox input").on("change", function () {
-          $(this).closest(".ui.checkbox").toggleClass("checked", $(this).prop("checked"));
-          updateContinueButton();
+        $("#cpiHelper_semanticui_modal .ui.checkbox").checkbox({
+          onChange: updateContinueButton,
         });
 
         updateContinueButton();

--- a/plugins/groovyDebugger.js
+++ b/plugins/groovyDebugger.js
@@ -1,19 +1,5 @@
 if (!window.groovyDebugSendToIDE) {
-  /**
-   * Global function for sending Groovy debug data to an external IDE.
-   * Reads the current IDE selection fresh from chrome.storage.sync on every call
-   * so changes made in the settings popup take effect immediately without a page reload.
-   * Exits early with an error toast if no IDE has been selected in plugin settings.
-   * Shows a confirmation dialog letting the user choose which data to transfer
-   * (body, script, properties, headers), then dispatches to sendToContivaIDE or
-   * sendToExternalIDE based on the selected IDE URL.
-   * @async
-   * @function groovyDebugSendToIDE
-   * @global
-   * @returns {Promise<void>} Resolves when the IDE tab has been opened, or returns
-   *   early if no IDE is selected or no debug data is available.
-   */
-  window.groovyDebugSendToIDE = async function () {
+  window.groovyDebugSendToIDE = async function (debugDataOverride) {
     const settings = await getPluginSettings("groovyDebugger");
     const ideSelection = settings["groovyDebugger---ideSelection"] || "";
 
@@ -24,9 +10,14 @@ if (!window.groovyDebugSendToIDE) {
 
     const customUrl = settings["groovyDebugger---customIdeUrl"] || "";
     const ideUrl = ideSelection === "custom" ? customUrl.trim() || "https://groovyide.com/cpi/share/v1/" : ideSelection;
-    const domain = new URL(ideUrl).hostname;
+    let domain;
+    try {
+      domain = new URL(ideUrl).hostname;
+    } catch (e) {
+      showToast("Invalid IDE URL: " + ideUrl, "Groovy Debugger", "Error");
+      return;
+    }
 
-    // Load last-used transfer preferences (defaults: body+script on, properties+headers off)
     const [_body, _script, _props, _hdrs] = await Promise.all([
       getStorageValue("groovyDebugger", "transferBody", "browser"),
       getStorageValue("groovyDebugger", "transferScript", "browser"),
@@ -50,7 +41,7 @@ if (!window.groovyDebugSendToIDE) {
           <i class="info circle icon"></i>
           <strong>Privacy Notice:</strong> The selected data may contain sensitive business information. Proceed with caution.
         </div>
-        <p><strong>Destination:</strong> ${domain}</p>
+        <p><strong>Destination:</strong> ${htmlEscape(domain)}</p>
         <p>Select which data you want to transfer to the external Groovy WebIDE:</p>
         <div class="ui form">
           <div class="grouped fields">
@@ -124,8 +115,7 @@ if (!window.groovyDebugSendToIDE) {
             syncChromeStoragePromise(getStoragePath("groovyDebugger", "transferHeaders", "browser"), transferOptions.headers),
           ]);
 
-          // Re-read settings at click time so any IDE change made while the dialog
-          // was open (Bug 3) is picked up without requiring a page reload.
+          // Re-read settings so any IDE change made while the dialog was open takes effect
           const latestSettings = await getPluginSettings("groovyDebugger");
           const latestIdeSelection = latestSettings["groovyDebugger---ideSelection"] || "";
 
@@ -136,7 +126,7 @@ if (!window.groovyDebugSendToIDE) {
             return;
           }
 
-          const debugData = window.currentGroovyDebugData;
+          const debugData = debugDataOverride || window.currentGroovyDebugData;
           if (!debugData) {
             showToast("No debug data available. Please click a Groovy step first.", "Groovy Debugger", "Error");
             return;
@@ -195,11 +185,17 @@ var plugin = {
       resetGroovyHighlighting();
 
       if (!active) {
-        return; // Deselected, just clear and exit
+        return;
       }
 
-      // Get artifactId directly via API call
-      const artifactId = await getArtifactIdDirectly();
+      let artifactId;
+      try {
+        artifactId = await getArtifactIdDirectly();
+      } catch (error) {
+        log.error("Groovy Debugger: error fetching artifactId:", error);
+        showToast("Could not fetch iFlow structure - " + error.message, "Groovy Debugger", "Error");
+        return;
+      }
       log.log("Groovy Debugger: artifactId=" + artifactId);
 
       if (!artifactId) {
@@ -212,14 +208,12 @@ var plugin = {
       try {
         const iFlowUrl = "https://" + pluginHelper.tenant + "/api/1.0/iflows/" + artifactId;
 
-        // Fetch the iFlow JSON structure
         const response = await fetch(iFlowUrl);
         if (!response.ok) {
           throw new Error(`HTTP error! Status: ${response.status}`);
         }
         const iFlowData = await response.json();
 
-        // Extract groovy script elements
         const groovyElements = extractGroovyElements(iFlowData);
 
         if (groovyElements.length === 0) {
@@ -230,20 +224,19 @@ var plugin = {
 
         log.log("Groovy Debugger: Found " + groovyElements.length + " groovy script elements");
 
-        // Reset any existing highlighting
         resetGroovyHighlighting();
 
-        // Get trace elements to identify which groovy steps have been executed
         await createInlineTraceElements(runInfo.messageGuid, false);
-        if (!inlineTraceElements?.length) {
+        // Snapshot: inlineTraceElements is a global that other calls can mutate
+        const traceElementsCopy = [...inlineTraceElements];
+        if (!traceElementsCopy.length) {
           $("#cpiHelper_waiting_model").modal("hide");
           showToast("No trace data found for this message", "Groovy Debugger", "Warning");
           return;
         }
 
-        // Find groovy elements that have corresponding trace data
         const groovyElementsWithTrace = groovyElements.filter((element) => {
-          const matchingTraceElements = inlineTraceElements.filter((traceElement) => {
+          const matchingTraceElements = traceElementsCopy.filter((traceElement) => {
             const traceId = traceElement.StepId || traceElement.ModelStepId;
             return traceId === element.id;
           });
@@ -256,10 +249,8 @@ var plugin = {
           return;
         }
 
-        // Highlight only groovy script elements that have trace data
         applyGroovyHighlighting(groovyElementsWithTrace);
 
-        // Store data for click handling
         window.groovyDebuggerData = {
           settings: settings,
           runInfo: runInfo,
@@ -267,7 +258,7 @@ var plugin = {
           iFlowData: iFlowData,
           iFlowUrl: iFlowUrl,
           artifactId: artifactId,
-          inlineTraceElements: inlineTraceElements,
+          inlineTraceElements: traceElementsCopy,
         };
 
         setupGroovyClickHandlers(settings, runInfo, groovyElementsWithTrace, iFlowData, artifactId, pluginHelper.tenant);
@@ -288,33 +279,22 @@ var plugin = {
   },
 };
 
-/**
- * Resets all Groovy highlighting and removes click handlers from BPMN shape elements.
- * Clears the fill color and cursor styles from all elements.
- * @function resetGroovyHighlighting
- */
+// Map to preserve SAP's native onclick handlers before we overwrite them
+const groovyOriginalHandlers = new Map();
+
 function resetGroovyHighlighting() {
   document.querySelectorAll("g[id^='BPMNShape_'] rect.activity").forEach((rect) => {
-    rect.style.fill = ""; // Reset fill for all elements
+    rect.style.fill = "";
   });
-  // Remove click handlers and cursor style from all BPMN shape elements
   document.querySelectorAll("g[id^='BPMNShape_']").forEach((element) => {
     element.style.cursor = "";
-    element.onclick = null;
+    element.onclick = groovyOriginalHandlers.get(element.id) || null;
   });
+  groovyOriginalHandlers.clear();
 }
 
-/**
- * Retrieves the artifact ID directly via API call for the current integration flow.
- * Handles both Neo and Cloud Foundry platforms with different API approaches.
- * @async
- * @function getArtifactIdDirectly
- * @returns {Promise<string>} The artifact ID of the integration flow
- * @throws {Error} If the integration flow is not found or API call fails
- */
 async function getArtifactIdDirectly() {
   try {
-    // Both Neo and CF share the same list-fetch — only the return value differs
     const listResponse = await makeCallPromise("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListCommand", false, null, null, null, null, true);
     const listData = new XmlToJson().parse(listResponse)["com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListResponse"];
     const artifact = Array.isArray(listData.artifactInformations)
@@ -341,7 +321,6 @@ async function getArtifactIdDirectly() {
       return JSON.parse(detailResponse).artifactInformation.id;
     }
 
-    // CF platform — artifact id from list is sufficient
     return artifact.id;
   } catch (error) {
     log.error("Error getting artifactId directly:", error);
@@ -349,15 +328,6 @@ async function getArtifactIdDirectly() {
   }
 }
 
-/**
- * Extracts Groovy script elements from the integration flow JSON data.
- * Filters elements to find only those with displayName "Groovy Script".
- * @function extractGroovyElements
- * @param {Object} iFlowData - The integration flow JSON structure
- * @param {Object} iFlowData.propertyViewModel - Property view model containing flow elements
- * @param {Array} iFlowData.propertyViewModel.listOfDefaultFlowElementModel - Array of flow elements
- * @returns {Array} Array of Groovy script elements with id, displayName, scriptFunction, and script properties
- */
 function extractGroovyElements(iFlowData) {
   if (!iFlowData.propertyViewModel?.listOfDefaultFlowElementModel) {
     return [];
@@ -373,56 +343,38 @@ function extractGroovyElements(iFlowData) {
     }));
 }
 
-/**
- * Applies green highlighting to found Groovy elements on the BPMN diagram.
- * Sets fill color to green (#13af00) for visual indication of debuggable steps.
- * @function applyGroovyHighlighting
- * @param {Array} groovyElements - Array of Groovy script elements to highlight
- * @param {Object} groovyElements[].id - Unique identifier of the element
- */
 function applyGroovyHighlighting(groovyElements) {
   groovyElements.forEach((element) => {
     const selector = `g#BPMNShape_${element.id}`;
     const targetElement = document.querySelector(selector);
 
     if (targetElement) {
-      // Find the rect inside the g element and apply fill color
       const rectElement = targetElement.querySelector("rect.activity");
       if (rectElement) {
-        rectElement.style.fill = "#13af00"; // Apply green fill for groovy steps
+        rectElement.style.fill = "#13af00";
       }
     }
   });
 }
 
-/**
- * Sets up click handlers for highlighted Groovy elements.
- * When clicked, displays debug popup with trace data for the selected Groovy step.
- * @function setupGroovyClickHandlers
- * @param {Object} settings - Plugin settings
- * @param {Object} runInfo - Runtime information for the message
- * @param {Array} groovyElements - Array of Groovy script elements
- * @param {Object} iFlowData - Integration flow JSON data
- * @param {string} artifactId - Artifact identifier
- * @param {string} tenant - Tenant name
- */
 function setupGroovyClickHandlers(settings, runInfo, groovyElements, iFlowData, artifactId, tenant) {
   groovyElements.forEach((element) => {
     const selector = `g#BPMNShape_${element.id}`;
     const targetElement = document.querySelector(selector);
 
     if (targetElement) {
+      if (!groovyOriginalHandlers.has(targetElement.id)) {
+        groovyOriginalHandlers.set(targetElement.id, targetElement.onclick);
+      }
       targetElement.style.cursor = "pointer";
       targetElement.onclick = async (event) => {
         event.stopPropagation();
         event.preventDefault();
 
         try {
-          // Try to get trace data for this element if available
           let debugData = await tryGetTraceDataForElement(runInfo, element, window.groovyDebuggerData.inlineTraceElements);
 
           if (!debugData) {
-            // Create basic debug data if no trace available
             debugData = {
               messageGuid: runInfo.messageGuid,
               stepId: element.id,
@@ -432,11 +384,10 @@ function setupGroovyClickHandlers(settings, runInfo, groovyElements, iFlowData, 
               timestamp: new Date().toISOString(),
             };
           } else {
-            // Set initial placeholder for script content (will be lazy loaded)
             debugData.groovyScript = "// Script content not available";
           }
 
-          // Store script fetching info for lazy loading
+          // Lazy-load script info so click handler can fetch Groovy source on demand
           debugData.scriptInfo = {
             tenant: tenant,
             artifactId: artifactId,
@@ -448,7 +399,7 @@ function setupGroovyClickHandlers(settings, runInfo, groovyElements, iFlowData, 
             callback: () => {
               let actionsDiv = $("#cpiHelper_semanticui_modal .actions");
               let debugBtn = $('<div class="ui positive button"><i class="rocket icon"></i>Debug Externally</div>');
-              debugBtn.on("click", () => window.groovyDebugSendToIDE());
+              debugBtn.on("click", () => window.groovyDebugSendToIDE(debugData));
               actionsDiv.prepend(debugBtn);
             },
           });
@@ -461,35 +412,21 @@ function setupGroovyClickHandlers(settings, runInfo, groovyElements, iFlowData, 
   });
 }
 
-/**
- * Attempts to get trace data for a specific element using pre-fetched trace elements.
- * Matches trace elements by StepId or ModelStepId to find corresponding execution data.
- * @async
- * @function tryGetTraceDataForElement
- * @param {Object} runInfo - Runtime information for the message
- * @param {Object} element - Groovy element to find trace data for
- * @param {string} element.id - Unique identifier of the element
- * @param {Array} inlineTraceElements - Array of pre-fetched trace elements
- * @returns {Promise<Object|null>} Debug data object if found, null otherwise
- */
 async function tryGetTraceDataForElement(runInfo, element, inlineTraceElements) {
   try {
-    // Use the pre-fetched trace elements instead of fetching again
     if (!inlineTraceElements?.length) {
-      return null; // No trace data available
+      return null;
     }
 
-    // Find trace elements that match this groovy element by ID
     const matchingTraceElements = inlineTraceElements.filter((traceElement) => {
       const traceId = traceElement.StepId || traceElement.ModelStepId;
       return traceId === element.id;
     });
 
     if (matchingTraceElements.length === 0) {
-      return null; // Step wasn't executed in this trace
+      return null;
     }
 
-    // Get debug data for the first matching trace element
     return await fetchGroovyDebugData(runInfo, matchingTraceElements[0], element.scriptFunction);
   } catch (error) {
     log.error("Error getting trace data for element:", error);
@@ -497,26 +434,12 @@ async function tryGetTraceDataForElement(runInfo, element, inlineTraceElements) 
   }
 }
 
-/**
- * Fetches debug data for a specific Groovy step from the CPI API.
- * Retrieves trace messages, properties, and run step information.
- * @async
- * @function fetchGroovyDebugData
- * @param {Object} runInfo - Runtime information containing message GUID
- * @param {Object} groovyStep - Trace element data for the Groovy step
- * @param {string} groovyStep.RunId - Run identifier
- * @param {number} groovyStep.ChildCount - Child count
- * @param {string} groovyStep.StepId - Step identifier
- * @param {string} scriptFunction - The actual Groovy function name from the iFlow element
- * @returns {Promise<Object|null>} Complete debug data object or null if failed
- */
 async function fetchGroovyDebugData(runInfo, groovyStep, scriptFunction) {
   try {
     var messageGuid = runInfo.messageGuid;
     var runId = groovyStep.RunId;
     var childCount = groovyStep.ChildCount;
 
-    // Get trace messages for this step
     var traceData = JSON.parse(
       await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/MessageProcessingLogRunSteps(RunId='" + runId + "',ChildCount=" + childCount + ")/TraceMessages?$format=json", true)
     ).d.results;
@@ -529,9 +452,6 @@ async function fetchGroovyDebugData(runInfo, groovyStep, scriptFunction) {
 
     var traceId = traceInfo.TraceId;
 
-    // Payload will be fetched lazily when Body tab is activated
-
-    // Get properties
     var properties = {};
     try {
       var propsData = JSON.parse(await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + traceId + ")/ExchangeProperties?$format=json", true)).d.results;
@@ -542,9 +462,7 @@ async function fetchGroovyDebugData(runInfo, groovyStep, scriptFunction) {
       log.log("No properties for this step");
     }
 
-    // Headers will be fetched lazily when Headers tab is activated
-
-    // Get run step data with properties for Log and Info tabs
+    // RunStepProperties contains the Log tab data; $expand fetches it in one call
     var runStepData = {};
     try {
       runStepData = JSON.parse(
@@ -574,23 +492,14 @@ async function fetchGroovyDebugData(runInfo, groovyStep, scriptFunction) {
   }
 }
 
-/**
- * Creates the HTML content for the Groovy debug popup with multiple tabs.
- * Uses lazy loading for performance - content is fetched only when tabs are activated.
- * @async
- * @function createGroovyDebugContent
- * @param {Object} data - Debug data object containing trace information
- * @param {string} data.traceId - The trace message ID
- * @param {Object} data.properties - Exchange properties
- * @param {Object} data.runStepData - Run step execution data
- * @param {Object} data.scriptInfo - Script metadata for lazy loading
- * @returns {Promise<string>} HTML content for the debug popup tabs
- */
 async function createGroovyDebugContent(data) {
-  // Lazy load body content when Body tab is activated
   let bodyContent = async () => {
     try {
       let payload = await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + data.traceId + ")/$value", true);
+      // Cache fetched payload on debugData so IDE transfer can reuse it
+      if (typeof payload === "string" && payload) {
+        data.payload = payload;
+      }
       return formatTrace(payload || "No payload", "groovyDebugBody", null, "payload.txt");
     } catch (error) {
       log.error("Error fetching body content:", error);
@@ -598,7 +507,6 @@ async function createGroovyDebugContent(data) {
     }
   };
 
-  // Lazy load headers content when Headers tab is activated
   let headersContent = async () => {
     try {
       let headersData = JSON.parse(await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + data.traceId + ")/Properties?$format=json", true)).d.results;
@@ -606,6 +514,7 @@ async function createGroovyDebugContent(data) {
       headersData.forEach((header) => {
         headers[header.Name] = header.Value;
       });
+      data.headers = headers;
       return formatHeadersAndPropertiesToTable(
         Object.keys(headers)
           .sort()
@@ -625,15 +534,19 @@ async function createGroovyDebugContent(data) {
       : []
   );
 
-  // Lazy load script content when Script tab is activated
   let scriptContent = async () => {
     try {
       const scriptUrl = resolveScriptUrl(data.scriptInfo);
       let groovyScriptContent = "// Script content not available";
       if (scriptUrl) {
         const scriptResponse = await fetch(scriptUrl);
-        const scriptData = await scriptResponse.json();
-        groovyScriptContent = scriptData.content || "// Script content not available";
+        if (scriptResponse.ok) {
+          const scriptData = await scriptResponse.json();
+          if (scriptData.content) {
+            groovyScriptContent = scriptData.content;
+            data.groovyScript = groovyScriptContent;
+          }
+        }
       }
       return formatTrace(groovyScriptContent, "groovyDebugScript", null, "script.groovy");
     } catch (error) {
@@ -642,10 +555,8 @@ async function createGroovyDebugContent(data) {
     }
   };
 
-  // Get Log content from stored run step data
   let logContent = formatLogContent(data.runStepData?.RunStepProperties?.results || []);
 
-  // Get Info content from stored run step data
   let infoContent = formatInfoContent(data.runStepData || {});
 
   let objects = [
@@ -659,19 +570,11 @@ async function createGroovyDebugContent(data) {
 
   let tabsContent = await createTabHTML(objects, "groovyDebugTabs");
 
-  // Store data globally for button access
   window.currentGroovyDebugData = data;
 
   return tabsContent;
 }
 
-/**
- * Formats log content from run step properties into an HTML table.
- * Sorts the log entries alphabetically by name.
- * @function formatLogContent
- * @param {Array} inputList - Array of log entries with Name and Value properties
- * @returns {string} HTML table string containing formatted log content
- */
 function formatLogContent(inputList) {
   inputList = inputList.sort(function (a, b) {
     return a.Name.toLowerCase() > b.Name.toLowerCase() ? 1 : -1;
@@ -680,26 +583,12 @@ function formatLogContent(inputList) {
   <thead><tr class="blue"><th>Name</th><th>Value</th></tr></thead>
   <tbody>`;
   inputList.forEach((item) => {
-    result += "<tr><td>" + item.Name + '</td><td style="word-break: break-all;">' + item.Value + "</td></tr>";
+    result += "<tr><td>" + htmlEscape(item.Name) + '</td><td style="word-break: break-all;">' + htmlEscape(item.Value) + "</td></tr>";
   });
   result += "</tbody></table>";
   return result;
 }
 
-/**
- * Formats run step information into an HTML table showing execution details.
- * Calculates and displays start/end times and duration information.
- * @function formatInfoContent
- * @param {Object} inputList - Run step data containing execution information
- * @param {string} inputList.StepStart - Start time in Microsoft JSON date format
- * @param {string} [inputList.StepStop] - End time in Microsoft JSON date format (optional)
- * @param {string} inputList.BranchId - Branch identifier
- * @param {string} inputList.RunId - Run identifier
- * @param {string} inputList.StepId - Step identifier
- * @param {string} inputList.ModelStepId - Model step identifier
- * @param {number} inputList.ChildCount - Child count
- * @returns {string} HTML table string containing formatted execution information
- */
 function formatInfoContent(inputList) {
   const valueList = [];
 
@@ -707,6 +596,7 @@ function formatInfoContent(inputList) {
     return "<div class='ui message'>No execution info available for this step.</div>";
   }
 
+  // CPI timestamps are OData /Date(epoch)/ format
   var stepStart = new Date(parseInt(inputList.StepStart.substr(6, 13)));
 
   valueList.push({
@@ -747,18 +637,13 @@ function formatInfoContent(inputList) {
   let result = `<table class='ui basic striped selectable compact table'><thead><tr class="blue"><th>Name</th><th>Value</th></tr></thead>
   <tbody>`;
   valueList.forEach((item) => {
-    result += "<tr><td>" + item.Name + '</td><td style="word-break: break-all;">' + item.Value + "</td></tr>";
+    result += "<tr><td>" + htmlEscape(item.Name) + '</td><td style="word-break: break-all;">' + htmlEscape(String(item.Value)) + "</td></tr>";
   });
   result += "</tbody></table>";
   return result;
 }
 
-/**
- * Resolves the full script fetch URL from scriptInfo, handling v2 path variants.
- * @function resolveScriptUrl
- * @param {Object} scriptInfo - Script metadata
- * @returns {string|null} Full URL to fetch the script, or null if unavailable
- */
+// Handles /script/v2/ path variant used by newer iFlow versions
 function resolveScriptUrl(scriptInfo) {
   if (!scriptInfo?.scriptPath) return null;
   let scriptPath = scriptInfo.scriptPath;
@@ -768,29 +653,21 @@ function resolveScriptUrl(scriptInfo) {
   return `https://${scriptInfo.tenant}/api/1.0/iflows/${scriptInfo.artifactId}/script/${scriptPath}${versionParam}`;
 }
 
-/**
- * Gathers and lazy-fetches all transfer data (script, payload, headers, properties)
- * based on the transfer options selected by the user.
- * @async
- * @function resolveTransferData
- * @param {Object} debugData - Complete debug data object
- * @param {Object} transferOptions - Which data types to transfer
- * @returns {Promise<{groovyScript: string, payload: string, headers: Object, properties: Object}>}
- */
 async function resolveTransferData(debugData, transferOptions) {
   let groovyScript = "";
   if (transferOptions.script) {
     groovyScript = debugData.groovyScript || "";
-    if (groovyScript === "// Script content not available") {
+    if (!groovyScript || groovyScript === "// Script content not available") {
       const scriptUrl = resolveScriptUrl(debugData.scriptInfo);
       if (scriptUrl) {
         try {
           const scriptResponse = await fetch(scriptUrl);
-          const scriptData = await scriptResponse.json();
-          groovyScript = scriptData.content || "";
+          if (scriptResponse.ok) {
+            const scriptData = await scriptResponse.json();
+            groovyScript = scriptData.content || "";
+          }
         } catch (e) {
           log.error("Error fetching script for IDE:", e);
-          groovyScript = "";
         }
       }
     }
@@ -801,7 +678,10 @@ async function resolveTransferData(debugData, transferOptions) {
     payload = debugData.payload || "";
     if (!payload && debugData.traceId) {
       try {
-        payload = await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + debugData.traceId + ")/$value", true);
+        const result = await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + debugData.traceId + ")/$value", true);
+        if (typeof result === "string") {
+          payload = result;
+        }
       } catch (e) {
         log.error("Error fetching payload for IDE:", e);
       }
@@ -828,27 +708,15 @@ async function resolveTransferData(debugData, transferOptions) {
   return { groovyScript, payload, headers, properties };
 }
 
-/**
- * Sends debug data to an external Groovy IDE (GroovyIDE.com or a custom URL).
- * The target URL is read from settings: if ideSelection is "custom" the user-supplied
- * customIdeUrl is used, otherwise ideSelection itself is the URL.
- * Data is compressed with pako deflateRaw and encoded as Base64URL before being
- * appended to the IDE URL and opened in a new tab.
- * @async
- * @function sendToExternalIDE
- * @param {Object} settings - Plugin settings
- * @param {Object} debugData - Complete debug data object
- * @param {Object} transferOptions - Options for which data types to transfer
- * @param {boolean} transferOptions.body - Whether to transfer message body
- * @param {boolean} transferOptions.properties - Whether to transfer properties
- * @param {boolean} transferOptions.headers - Whether to transfer headers
- * @param {boolean} transferOptions.script - Whether to transfer script
- * @returns {Promise<void>} Resolves when the IDE tab has been opened
- */
 async function sendToExternalIDE(settings, debugData, transferOptions = { body: true, properties: true, headers: true, script: true }) {
   const ideSelection = settings["groovyDebugger---ideSelection"] || "https://groovyide.com/cpi/share/v1/";
   const customUrl = settings["groovyDebugger---customIdeUrl"] || "";
   const ideUrl = ideSelection === "custom" ? customUrl.trim() || "https://groovyide.com/cpi/share/v1/" : ideSelection;
+
+  if (typeof pako === "undefined") {
+    showToast("Compression library not loaded. Please reload the page.", "Groovy Debugger", "Error");
+    return;
+  }
 
   const { groovyScript, payload, headers, properties } = await resolveTransferData(debugData, transferOptions);
 
@@ -863,19 +731,14 @@ async function sendToExternalIDE(settings, debugData, transferOptions = { body: 
   window.open(ideUrl + encoded, "_blank");
 }
 
-/**
- * Converts CPI Helper debug data to Contiva format and opens in Contiva IDE.
- * The target URL is read from settings (ideSelection), falling back to the
- * default Contiva URL if not set.
- * Contiva encoding: JSON → ZIP (JSZip) → Gzip (pako) → standard Base64 → URL-encode.
- * @async
- * @function sendToContivaIDE
- * @param {Object} settings - Plugin settings
- * @param {Object} debugData - Complete debug data object
- * @param {Object} transferOptions - Which data types to transfer
- */
+// Contiva encoding: JSON -> ZIP (JSZip) -> Gzip (pako) -> standard Base64 -> URL-encode
 async function sendToContivaIDE(settings, debugData, transferOptions = { body: true, properties: true, headers: true, script: true }) {
   const contivaUrl = settings["groovyDebugger---ideSelection"] || "https://ide.contiva.com/cpi/script/debug";
+
+  if (typeof pako === "undefined" || typeof JSZip === "undefined") {
+    showToast("Compression libraries not loaded. Please reload the page.", "Groovy Debugger", "Error");
+    return;
+  }
 
   const { groovyScript, payload, headers, properties } = await resolveTransferData(debugData, transferOptions);
 
@@ -892,19 +755,10 @@ async function sendToContivaIDE(settings, debugData, transferOptions = { body: t
   window.open(contivaUrl + "?data=" + encoded, "_blank");
 }
 
-/**
- * Encodes Contiva format data for the Contiva IDE URL.
- * Pipeline: JSON → ZIP (JSZip, epoch date) → Gzip (pako, mtime=0)
- *           → standard Base64 (with padding) → URL-encode (encodeURIComponent).
- * @async
- * @function compressToContivaBase64
- * @param {Object} contivaData - Contiva format object to encode
- * @returns {Promise<string>} URL-encoded standard Base64 string
- */
 async function compressToContivaBase64(contivaData) {
   const jsonString = JSON.stringify(contivaData);
 
-  // Use epoch date (new Date(0)) for deterministic ZIP output
+  // epoch date for deterministic ZIP output
   const zip = new JSZip();
   zip.file("data.json", jsonString, { date: new Date(0) });
   const zipBytes = await zip.generateAsync({
@@ -913,10 +767,10 @@ async function compressToContivaBase64(contivaData) {
     compressionOptions: { level: 9 },
   });
 
-  // mtime: 0 keeps the gzip header deterministic
+  // mtime: 0 for deterministic gzip header
   const gzipped = pako.gzip(zipBytes, { level: 9, mtime: 0 });
 
-  // Standard Base64 — NOT URL-safe (keep + and /)
+  // Standard Base64 (NOT URL-safe) — Contiva expects + and /
   let binary = "";
   for (let i = 0; i < gzipped.length; i++) {
     binary += String.fromCharCode(gzipped[i]);
@@ -929,29 +783,14 @@ async function compressToContivaBase64(contivaData) {
   return encodeURIComponent(base64);
 }
 
-/**
- * Compresses a data string using pako deflateRaw and encodes to Base64URL.
- * Used for compressing debug data before sending to external IDE.
- * @function compressToBase64
- * @param {string} dataString - JSON string to compress and encode
- * @returns {string} Compressed and Base64URL encoded string
- */
 function compressToBase64(dataString) {
   const dataBytes = new TextEncoder().encode(dataString);
 
-  // Raw Deflate stream — no Zlib/Gzip headers
   const compressedBytes = pako.deflateRaw(dataBytes, { level: 9 });
 
   return uint8ArrayToBase64Url(compressedBytes);
 }
 
-/**
- * Converts a Uint8Array to a Base64URL encoded string.
- * Used for URL-safe encoding of binary data.
- * @function uint8ArrayToBase64Url
- * @param {Uint8Array} bytes - Binary data to encode
- * @returns {string} Base64URL encoded string
- */
 function uint8ArrayToBase64Url(bytes) {
   let binaryString = "";
   bytes.forEach((byte) => {

--- a/plugins/xsltDebugX.js
+++ b/plugins/xsltDebugX.js
@@ -1,20 +1,6 @@
 if (!window.xsltDebugSendToIDE) {
-  /**
-   * Global function for sending XSLT debug data to an external IDE.
-   * Reads the current IDE selection fresh from chrome.storage.sync on every call
-   * so changes made in the settings popup take effect immediately without a page reload.
-   * Exits early with an error toast if no IDE has been selected in plugin settings.
-   * Shows a confirmation dialog letting the user choose which data to transfer
-   * (body, script, properties, headers), then dispatches to sendToXSLTIDE.
-   * @async
-   * @function xsltDebugSendToIDE
-   * @global
-   * @returns {Promise<void>} Resolves when the IDE tab has been opened, or returns
-   *   early if no IDE is selected or no debug data is available.
-   */
   window.xsltDebugSendToIDE = async function (debugDataOverride) {
     const settings = await getPluginSettings("xsltDebugX");
-    // Default to the built-in IDE if user hasn't visited settings yet
     const ideSelection = settings["xsltDebugX---ideSelection"] || "https://xsltdebugx.pages.dev/";
 
     const customUrl = settings["xsltDebugX---customIdeUrl"] || "";
@@ -27,7 +13,6 @@ if (!window.xsltDebugSendToIDE) {
       return;
     }
 
-    // Load last-used transfer preferences (defaults: body+script on, properties+headers off)
     const [_body, _script, _props, _hdrs] = await Promise.all([
       getStorageValue("xsltDebugX", "transferBody", "browser"),
       getStorageValue("xsltDebugX", "transferScript", "browser"),
@@ -108,7 +93,7 @@ if (!window.xsltDebugSendToIDE) {
           continueBtn.toggleClass("disabled", !anyChecked).prop("disabled", !anyChecked);
         };
 
-        // Initialize Semantic UI toggle checkboxes
+        // Semantic UI requires explicit .checkbox() initialization for toggle behavior
         $("#cpiHelper_semanticui_modal .ui.checkbox").checkbox({
           onChange: updateContinueButton,
         });
@@ -130,8 +115,7 @@ if (!window.xsltDebugSendToIDE) {
             syncChromeStoragePromise(getStoragePath("xsltDebugX", "transferHeaders", "browser"), transferOptions.headers),
           ]);
 
-          // Re-read settings at click time so any IDE change made while the dialog
-          // was open is picked up without requiring a page reload.
+          // Re-read settings so any IDE change made while the dialog was open takes effect
           const latestSettings = await getPluginSettings("xsltDebugX");
 
           $("#cpiHelper_semanticui_modal").modal("hide");
@@ -155,7 +139,29 @@ if (!window.xsltDebugSendToIDE) {
   };
 }
 
+// Map to preserve SAP's native onclick handlers before we overwrite them
 const xsltOriginalHandlers = new Map();
+
+async function getXSLTArtifactId() {
+  const listResponse = await makeCallPromise("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListCommand", false, null, null, null, null, true);
+  const listData = new XmlToJson().parse(listResponse)["com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentsListResponse"];
+  const artifact = Array.isArray(listData.artifactInformations)
+    ? listData.artifactInformations.find((e) => e.symbolicName === cpiData.integrationFlowId)
+    : listData.artifactInformations?.symbolicName === cpiData.integrationFlowId
+      ? listData.artifactInformations
+      : null;
+
+  if (!artifact) {
+    throw new Error("Integration Flow not found in list");
+  }
+
+  if (cpiData.cpiPlatform === "neo") {
+    const detailResponse = await makeCallPromise("GET", "/" + cpiData.urlExtension + "Operations/com.sap.it.op.tmn.commands.dashboard.webui.IntegrationComponentDetailCommand?artifactId=" + artifact.id, 60, "application/json", null, null, null, true);
+    return JSON.parse(detailResponse).artifactInformation.id;
+  }
+
+  return artifact.id;
+}
 
 var plugin = {
   metadataVersion: "1.0.0",
@@ -192,17 +198,12 @@ var plugin = {
       resetXSLTHighlighting();
 
       if (!active) {
-        return; // Deselected, just clear and exit
-      }
-
-      // Get artifactId directly via API call (function defined in groovyDebugger.js, always loaded)
-      if (typeof getArtifactIdDirectly !== "function") {
-        showToast("Required helper function not available. Ensure the GroovyDebugX plugin is enabled.", "XSLT Debugger", "Error");
         return;
       }
+
       let artifactId;
       try {
-        artifactId = await getArtifactIdDirectly();
+        artifactId = await getXSLTArtifactId();
       } catch (error) {
         log.error("XSLT Debugger: error fetching artifactId:", error);
         showToast("Could not fetch iFlow structure - " + error.message, "XSLT Debugger", "Error");
@@ -220,14 +221,12 @@ var plugin = {
       try {
         const iFlowUrl = "https://" + pluginHelper.tenant + "/api/1.0/iflows/" + artifactId;
 
-        // Fetch the iFlow JSON structure
         const response = await fetch(iFlowUrl);
         if (!response.ok) {
           throw new Error(`HTTP error! Status: ${response.status}`);
         }
         const iFlowData = await response.json();
 
-        // Extract XSLT mapping elements
         const xsltElements = extractXSLTElements(iFlowData);
 
         if (xsltElements.length === 0) {
@@ -238,11 +237,10 @@ var plugin = {
 
         log.log("XSLT Debugger: Found " + xsltElements.length + " XSLT mapping elements");
 
-        // Reset any existing highlighting
         resetXSLTHighlighting();
 
-        // Get trace elements to identify which XSLT steps have been executed
         await createInlineTraceElements(runInfo.messageGuid, false);
+        // Snapshot: inlineTraceElements is a global that other calls can mutate
         const traceElementsCopy = [...inlineTraceElements];
         if (!traceElementsCopy.length) {
           $("#cpiHelper_waiting_model").modal("hide");
@@ -250,7 +248,6 @@ var plugin = {
           return;
         }
 
-        // Find XSLT elements that have corresponding trace data
         const xsltElementsWithTrace = xsltElements.filter((element) => {
           const matchingTraceElements = traceElementsCopy.filter((traceElement) => {
             const traceId = traceElement.StepId || traceElement.ModelStepId;
@@ -265,10 +262,8 @@ var plugin = {
           return;
         }
 
-        // Highlight only XSLT mapping elements that have trace data
         applyXSLTHighlighting(xsltElementsWithTrace);
 
-        // Store data for click handling
         window.xsltDebuggerData = {
           settings: settings,
           runInfo: runInfo,
@@ -297,11 +292,6 @@ var plugin = {
   },
 };
 
-/**
- * Resets all XSLT highlighting and removes click handlers from BPMN shape elements.
- * Clears the fill color and cursor styles from all elements.
- * @function resetXSLTHighlighting
- */
 function resetXSLTHighlighting() {
   document.querySelectorAll("g[id^='BPMNShape_'] rect.activity").forEach((rect) => {
     rect.style.fill = "";
@@ -313,13 +303,6 @@ function resetXSLTHighlighting() {
   xsltOriginalHandlers.clear();
 }
 
-/**
- * Extracts XSLT mapping elements from the integration flow JSON data.
- * Filters elements to find only those with displayName "XSLT Mapping".
- * @function extractXSLTElements
- * @param {Object} iFlowData - The integration flow JSON structure
- * @returns {Array} Array of XSLT mapping elements with id, displayName, mappingPath, and filename
- */
 function extractXSLTElements(iFlowData) {
   if (!iFlowData.propertyViewModel?.listOfDefaultFlowElementModel) {
     return [];
@@ -340,12 +323,6 @@ function extractXSLTElements(iFlowData) {
     });
 }
 
-/**
- * Applies green highlighting to found XSLT elements on the BPMN diagram.
- * Sets fill color to green (#13af00) for visual indication of debuggable steps.
- * @function applyXSLTHighlighting
- * @param {Array} xsltElements - Array of XSLT mapping elements to highlight
- */
 function applyXSLTHighlighting(xsltElements) {
   xsltElements.forEach((element) => {
     const selector = `g#BPMNShape_${element.id}`;
@@ -360,17 +337,6 @@ function applyXSLTHighlighting(xsltElements) {
   });
 }
 
-/**
- * Sets up click handlers for highlighted XSLT elements.
- * When clicked, displays debug popup with trace data for the selected XSLT step.
- * @function setupXSLTClickHandlers
- * @param {Object} settings - Plugin settings
- * @param {Object} runInfo - Runtime information for the message
- * @param {Array} xsltElements - Array of XSLT mapping elements
- * @param {Object} iFlowData - Integration flow JSON data
- * @param {string} artifactId - Artifact identifier
- * @param {string} tenant - Tenant name
- */
 function setupXSLTClickHandlers(settings, runInfo, xsltElements, iFlowData, artifactId, tenant) {
   xsltElements.forEach((element) => {
     const selector = `g#BPMNShape_${element.id}`;
@@ -397,7 +363,7 @@ function setupXSLTClickHandlers(settings, runInfo, xsltElements, iFlowData, arti
             };
           }
 
-          // Store script fetching info for lazy loading
+          // Lazy-load script info so click handler can fetch XSLT source on demand
           debugData.scriptInfo = {
             tenant: tenant,
             artifactId: artifactId,
@@ -422,15 +388,6 @@ function setupXSLTClickHandlers(settings, runInfo, xsltElements, iFlowData, arti
   });
 }
 
-/**
- * Attempts to get trace data for a specific XSLT element using pre-fetched trace elements.
- * @async
- * @function tryGetXSLTTraceDataForElement
- * @param {Object} runInfo - Runtime information for the message
- * @param {Object} element - XSLT element to find trace data for
- * @param {Array} inlineTraceElements - Array of pre-fetched trace elements
- * @returns {Promise<Object|null>} Debug data object if found, null otherwise
- */
 async function tryGetXSLTTraceDataForElement(runInfo, element, inlineTraceElements) {
   try {
     if (!inlineTraceElements?.length) {
@@ -453,22 +410,12 @@ async function tryGetXSLTTraceDataForElement(runInfo, element, inlineTraceElemen
   }
 }
 
-/**
- * Fetches debug data for a specific XSLT step from the CPI API.
- * Retrieves trace messages, exchange properties, and run step information.
- * @async
- * @function fetchXSLTDebugData
- * @param {Object} runInfo - Runtime information containing message GUID
- * @param {Object} xsltStep - Trace element data for the XSLT step
- * @returns {Promise<Object|null>} Complete debug data object or null if failed
- */
 async function fetchXSLTDebugData(runInfo, xsltStep) {
   try {
     var messageGuid = runInfo.messageGuid;
     var runId = xsltStep.RunId;
     var childCount = xsltStep.ChildCount;
 
-    // Get trace messages for this step
     var traceData = JSON.parse(
       await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/MessageProcessingLogRunSteps(RunId='" + runId + "',ChildCount=" + childCount + ")/TraceMessages?$format=json", true)
     ).d.results;
@@ -481,7 +428,6 @@ async function fetchXSLTDebugData(runInfo, xsltStep) {
 
     var traceId = traceInfo.TraceId;
 
-    // Get exchange properties
     var properties = {};
     try {
       var propsData = JSON.parse(await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + traceId + ")/ExchangeProperties?$format=json", true)).d.results;
@@ -492,7 +438,7 @@ async function fetchXSLTDebugData(runInfo, xsltStep) {
       log.log("No properties for this XSLT step");
     }
 
-    // Get run step data with properties for Log and Info tabs
+    // RunStepProperties contains the Log tab data; $expand fetches it in one call
     var runStepData = {};
     try {
       runStepData = JSON.parse(
@@ -518,20 +464,12 @@ async function fetchXSLTDebugData(runInfo, xsltStep) {
   }
 }
 
-/**
- * Creates the HTML content for the XSLT debug popup with multiple tabs.
- * Uses lazy loading for performance - content is fetched only when tabs are activated.
- * @async
- * @function createXSLTDebugContent
- * @param {Object} data - Debug data object containing trace information
- * @returns {Promise<string>} HTML content for the debug popup tabs
- */
 async function createXSLTDebugContent(data) {
-  // Lazy load body content when Body tab is activated
   let bodyContent = async () => {
     if (!data.traceId) return "<div>No trace data available for this step.</div>";
     try {
       let payload = await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + data.traceId + ")/$value", true);
+      // Cache fetched payload on debugData so IDE transfer can reuse it
       if (typeof payload === "string" && payload) {
         data.payload = payload;
       }
@@ -542,7 +480,6 @@ async function createXSLTDebugContent(data) {
     }
   };
 
-  // Lazy load headers content when Headers tab is activated
   let headersContent = async () => {
     if (!data.traceId) return "<div>No trace data available for this step.</div>";
     try {
@@ -571,7 +508,6 @@ async function createXSLTDebugContent(data) {
       : []
   );
 
-  // Lazy load XSLT script content when Script tab is activated
   let scriptContent = async () => {
     try {
       const scriptUrl = resolveXSLTScriptUrl(data.scriptInfo);
@@ -593,10 +529,8 @@ async function createXSLTDebugContent(data) {
     }
   };
 
-  // Get Log content from stored run step data
   let logContent = formatXSLTLogContent(data.runStepData?.RunStepProperties?.results || []);
 
-  // Get Info content from stored run step data
   let infoContent = formatXSLTInfoContent(data.runStepData || {});
 
   let objects = [
@@ -610,18 +544,11 @@ async function createXSLTDebugContent(data) {
 
   let tabsContent = await createTabHTML(objects, "xsltDebugTabs");
 
-  // Store data globally for button access
   window.currentXSLTDebugData = data;
 
   return tabsContent;
 }
 
-/**
- * Formats log content from run step properties into an HTML table.
- * @function formatXSLTLogContent
- * @param {Array} inputList - Array of log entries with Name and Value properties
- * @returns {string} HTML table string containing formatted log content
- */
 function formatXSLTLogContent(inputList) {
   inputList = inputList.sort(function (a, b) {
     return a.Name.toLowerCase() > b.Name.toLowerCase() ? 1 : -1;
@@ -636,13 +563,6 @@ function formatXSLTLogContent(inputList) {
   return result;
 }
 
-/**
- * Formats run step information into an HTML table showing execution details.
- * Calculates and displays start/end times and duration information.
- * @function formatXSLTInfoContent
- * @param {Object} inputList - Run step data containing execution information
- * @returns {string} HTML table string containing formatted execution information
- */
 function formatXSLTInfoContent(inputList) {
   const valueList = [];
 
@@ -650,6 +570,7 @@ function formatXSLTInfoContent(inputList) {
     return "<div class='ui message'>No execution info available for this step.</div>";
   }
 
+  // CPI timestamps are OData /Date(epoch)/ format
   var stepStart = new Date(parseInt(inputList.StepStart.substr(6, 13)));
 
   valueList.push({
@@ -692,28 +613,12 @@ function formatXSLTInfoContent(inputList) {
   return result;
 }
 
-/**
- * Resolves the full XSLT resource fetch URL from scriptInfo.
- * Uses the CPI resource API endpoint for XSLT mapping files.
- * API: /api/1.0/iflows/{artifactId}/resource/{filename}?resourceLocation=mapping&resourcePersistenceType=&artifactType=
- * @function resolveXSLTScriptUrl
- * @param {Object} scriptInfo - Script metadata with tenant, artifactId, filename
- * @returns {string|null} Full URL to fetch the XSLT script, or null if unavailable
- */
+// API: /api/1.0/iflows/{artifactId}/resource/{filename}?resourceLocation=mapping
 function resolveXSLTScriptUrl(scriptInfo) {
   if (!scriptInfo?.filename) return null;
   return `https://${scriptInfo.tenant}/api/1.0/iflows/${scriptInfo.artifactId}/resource/${encodeURIComponent(scriptInfo.filename)}?resourceLocation=mapping&resourcePersistenceType=&artifactType=`;
 }
 
-/**
- * Gathers and lazy-fetches all transfer data (script, payload, headers, properties)
- * based on the transfer options selected by the user.
- * @async
- * @function resolveXSLTTransferData
- * @param {Object} debugData - Complete debug data object
- * @param {Object} transferOptions - Which data types to transfer
- * @returns {Promise<{xsltScript: string, payload: string, headers: Object, properties: Object}>}
- */
 async function resolveXSLTTransferData(debugData, transferOptions) {
   let xsltScript = "";
   if (transferOptions.script) {
@@ -769,19 +674,7 @@ async function resolveXSLTTransferData(debugData, transferOptions) {
   return { xsltScript, payload, headers, properties };
 }
 
-/**
- * Sends XSLT debug data to an external XSLT IDE.
- * The target URL is read from settings: if ideSelection is "custom" the user-supplied
- * customIdeUrl is used, otherwise ideSelection itself is the URL.
- * Data is encoded using pako.deflateRaw compression + URL-safe base64 and appended
- * as a #share/ hash fragment so the IDE can decode it on load.
- * @async
- * @function sendToXSLTIDE
- * @param {Object} settings - Plugin settings
- * @param {Object} debugData - Complete debug data object
- * @param {Object} transferOptions - Options for which data types to transfer
- * @returns {Promise<void>} Resolves when the IDE tab has been opened
- */
+// Compress with pako.deflateRaw + URL-safe base64 (matches xsltdebugx.pages.dev #share/ format)
 async function sendToXSLTIDE(settings, debugData, transferOptions = { body: true, properties: true, headers: true, script: true }) {
   const ideSelection = settings["xsltDebugX---ideSelection"] || "https://xsltdebugx.pages.dev/";
   const customUrl = settings["xsltDebugX---customIdeUrl"] || "";
@@ -801,7 +694,6 @@ async function sendToXSLTIDE(settings, debugData, transferOptions = { body: true
     properties: Object.keys(properties).map(name => ({ name, value: properties[name] })),
   };
 
-  // Compress with pako.deflateRaw + URL-safe base64 (matches xsltdebugx.pages.dev share format)
   const bytes      = new TextEncoder().encode(JSON.stringify(sharePayload));
   const compressed = pako.deflateRaw(bytes, { level: 9 });
   const CHUNK = 8192;

--- a/plugins/xsltDebugX.js
+++ b/plugins/xsltDebugX.js
@@ -1,0 +1,784 @@
+if (!window.xsltDebugSendToIDE) {
+  /**
+   * Global function for sending XSLT debug data to an external IDE.
+   * Reads the current IDE selection fresh from chrome.storage.sync on every call
+   * so changes made in the settings popup take effect immediately without a page reload.
+   * Exits early with an error toast if no IDE has been selected in plugin settings.
+   * Shows a confirmation dialog letting the user choose which data to transfer
+   * (body, script, properties, headers), then dispatches to sendToXSLTIDE.
+   * @async
+   * @function xsltDebugSendToIDE
+   * @global
+   * @returns {Promise<void>} Resolves when the IDE tab has been opened, or returns
+   *   early if no IDE is selected or no debug data is available.
+   */
+  window.xsltDebugSendToIDE = async function () {
+    const settings = await getPluginSettings("xsltDebugX");
+    // Default to the built-in IDE if user hasn't visited settings yet
+    const ideSelection = settings["xsltDebugX---ideSelection"] || "https://xsltdebugx.pages.dev/";
+
+    const customUrl = settings["xsltDebugX---customIdeUrl"] || "";
+    const ideUrl = ideSelection === "custom" ? customUrl.trim() || "https://xsltdebugx.pages.dev/" : ideSelection;
+    const domain = new URL(ideUrl).hostname;
+
+    // Load last-used transfer preferences (defaults: body+script on, properties+headers off)
+    const [_body, _script, _props, _hdrs] = await Promise.all([
+      getStorageValue("xsltDebugX", "transferBody", "browser"),
+      getStorageValue("xsltDebugX", "transferScript", "browser"),
+      getStorageValue("xsltDebugX", "transferProperties", "browser"),
+      getStorageValue("xsltDebugX", "transferHeaders", "browser"),
+    ]);
+    const prefs = {
+      body: _body !== "" ? !!_body : true,
+      script: _script !== "" ? !!_script : true,
+      properties: _props !== "" ? !!_props : false,
+      headers: _hdrs !== "" ? !!_hdrs : false,
+    };
+
+    const popupContent = `
+      <div class="ui warning message">
+        <div class="header">
+          <i class="exclamation triangle icon"></i>
+          Data Transfer Confirmation
+        </div>
+        <div class="ui info message">
+          <i class="info circle icon"></i>
+          <strong>Privacy Notice:</strong> The selected data may contain sensitive business information. Proceed with caution.
+        </div>
+        <p><strong>Destination:</strong> ${domain}</p>
+        <p>Select which data you want to transfer to the external XSLT WebIDE:</p>
+        <div class="ui form">
+          <div class="grouped fields">
+            <div class="field">
+              <div class="ui checkbox ${prefs.body ? "checked" : ""}" id="xslt-transfer-body">
+                <input type="checkbox" name="xslt-transfer-body" ${prefs.body ? "checked" : ""}>
+                <label>Message Body <em>(may contain sensitive data)</em></label>
+              </div>
+            </div>
+            <div class="field">
+              <div class="ui checkbox ${prefs.script ? "checked" : ""}" id="xslt-transfer-script">
+                <input type="checkbox" name="xslt-transfer-script" ${prefs.script ? "checked" : ""}>
+                <label>XSLT Script <em>(source code)</em></label>
+              </div>
+            </div>
+            <div class="field">
+              <div class="ui checkbox ${prefs.properties ? "checked" : ""}" id="xslt-transfer-properties">
+                <input type="checkbox" name="xslt-transfer-properties" ${prefs.properties ? "checked" : ""}>
+                <label>Properties <em>(may contain configuration data)</em></label>
+              </div>
+            </div>
+            <div class="field">
+              <div class="ui checkbox ${prefs.headers ? "checked" : ""}" id="xslt-transfer-headers">
+                <input type="checkbox" name="xslt-transfer-headers" ${prefs.headers ? "checked" : ""}>
+                <label>Headers <em>(may contain security & metadata)</em></label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    showBigPopup(popupContent, "Confirm Data Transfer", {
+      fullscreen: false,
+      large: false,
+      callback: () => {
+        let actionsDiv = $("#cpiHelper_semanticui_modal .actions");
+        actionsDiv.empty();
+
+        let cancelBtn = $('<div class="ui button">Cancel</div>');
+        cancelBtn.on("click", () => {
+          $("#cpiHelper_semanticui_modal").modal("hide");
+        });
+        actionsDiv.append(cancelBtn);
+
+        let continueBtn = $('<div class="ui positive button"><i class="rocket icon"></i>Continue</div>');
+
+        const updateContinueButton = () => {
+          const anyChecked =
+            $("#xslt-transfer-body input").prop("checked") ||
+            $("#xslt-transfer-properties input").prop("checked") ||
+            $("#xslt-transfer-headers input").prop("checked") ||
+            $("#xslt-transfer-script input").prop("checked");
+          continueBtn.toggleClass("disabled", !anyChecked).prop("disabled", !anyChecked);
+        };
+
+        $("#cpiHelper_semanticui_modal .ui.checkbox input").on("change", function () {
+          $(this).closest(".ui.checkbox").toggleClass("checked", $(this).prop("checked"));
+          updateContinueButton();
+        });
+
+        updateContinueButton();
+
+        continueBtn.on("click", async () => {
+          const transferOptions = {
+            body: $("#xslt-transfer-body input").prop("checked"),
+            properties: $("#xslt-transfer-properties input").prop("checked"),
+            headers: $("#xslt-transfer-headers input").prop("checked"),
+            script: $("#xslt-transfer-script input").prop("checked"),
+          };
+
+          await Promise.all([
+            syncChromeStoragePromise(getStoragePath("xsltDebugX", "transferBody", "browser"), transferOptions.body),
+            syncChromeStoragePromise(getStoragePath("xsltDebugX", "transferScript", "browser"), transferOptions.script),
+            syncChromeStoragePromise(getStoragePath("xsltDebugX", "transferProperties", "browser"), transferOptions.properties),
+            syncChromeStoragePromise(getStoragePath("xsltDebugX", "transferHeaders", "browser"), transferOptions.headers),
+          ]);
+
+          // Re-read settings at click time so any IDE change made while the dialog
+          // was open is picked up without requiring a page reload.
+          const latestSettings = await getPluginSettings("xsltDebugX");
+
+          $("#cpiHelper_semanticui_modal").modal("hide");
+
+          const debugData = window.currentXSLTDebugData;
+          if (!debugData) {
+            showToast("No debug data available. Please click an XSLT step first.", "XSLT Debugger", "Error");
+            return;
+          }
+          try {
+            await sendToXSLTIDE(latestSettings, debugData, transferOptions);
+            showToast("Debug data sent to IDE", "Success");
+          } catch (e) {
+            log.error("Error sending to XSLT IDE:", e);
+            showToast("Failed to send to IDE: " + e.message, "XSLT Debugger", "Error");
+          }
+        });
+        actionsDiv.append(continueBtn);
+      },
+    });
+  };
+}
+
+var plugin = {
+  metadataVersion: "1.0.0",
+  id: "xsltDebugX",
+  name: "XSLTDebugX IDE",
+  version: "1.0.0",
+  author: "Sunil Pharswan",
+  email: "sunilpharswan4198@gmail.com",
+  website: "https://linkedin.com/in/sunilph",
+  description:
+    "<b>XSLTDebugX</b> streamlines XSLT debugging by automating runtime trace extraction. With visual step highlighting and one-click data transfer to <b>XSLT WebIDE</b>, it eliminates manual data entry and accelerates your integration development.<br><br><b>Note</b>: Requires the message to be processed in <b>Trace Mode</b> to capture and transfer runtime data.",
+  settings: {
+    ideSelection: {
+      text: "External XSLT IDE",
+      type: "radio",
+      scope: "browser",
+      options: [
+        { value: "https://xsltdebugx.pages.dev/", label: "XSLTDebugX IDE (xsltdebugx.pages.dev)", default: true },
+        { value: "custom", label: "Custom URL" },
+      ],
+    },
+    customIdeUrl: {
+      text: "Custom IDE URL",
+      type: "textinput",
+      scope: "browser",
+      placeholder: "https://your-custom-ide.com/share/",
+      showWhen: { key: "ideSelection", value: "custom" },
+    },
+  },
+  messageSidebarButton: {
+    icon: { text: "<>", type: "text" },
+    title: "Debug XSLT Steps",
+    onClick: async (pluginHelper, settings, runInfo, active) => {
+      resetXSLTHighlighting();
+
+      if (!active) {
+        return; // Deselected, just clear and exit
+      }
+
+      // Get artifactId directly via API call (function defined in groovyDebugger.js, always loaded)
+      if (typeof getArtifactIdDirectly !== "function") {
+        showToast("Required helper function not available. Ensure the GroovyDebugX plugin is enabled.", "XSLT Debugger", "Error");
+        return;
+      }
+      let artifactId;
+      try {
+        artifactId = await getArtifactIdDirectly();
+      } catch (error) {
+        log.error("XSLT Debugger: error fetching artifactId:", error);
+        showToast("Could not fetch iFlow structure - " + error.message, "XSLT Debugger", "Error");
+        return;
+      }
+      log.log("XSLT Debugger: artifactId=" + artifactId);
+
+      if (!artifactId) {
+        showToast("Could not fetch iFlow structure - make sure you're on an integration flow page", "XSLT Debugger", "Error");
+        return;
+      }
+
+      showWaitingPopup("Fetching iFlow data, trace information and highlighting XSLT steps with data...", "ui blue");
+
+      try {
+        const iFlowUrl = "https://" + pluginHelper.tenant + "/api/1.0/iflows/" + artifactId;
+
+        // Fetch the iFlow JSON structure
+        const response = await fetch(iFlowUrl);
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+        const iFlowData = await response.json();
+
+        // Extract XSLT mapping elements
+        const xsltElements = extractXSLTElements(iFlowData);
+
+        if (xsltElements.length === 0) {
+          $("#cpiHelper_waiting_model").modal("hide");
+          showToast("No XSLT Mapping steps found in this integration flow", "XSLT Debugger", "Warning");
+          return;
+        }
+
+        log.log("XSLT Debugger: Found " + xsltElements.length + " XSLT mapping elements");
+
+        // Reset any existing highlighting
+        resetXSLTHighlighting();
+
+        // Get trace elements to identify which XSLT steps have been executed
+        await createInlineTraceElements(runInfo.messageGuid, false);
+        if (!inlineTraceElements?.length) {
+          $("#cpiHelper_waiting_model").modal("hide");
+          showToast("No trace data found for this message", "XSLT Debugger", "Warning");
+          return;
+        }
+
+        // Find XSLT elements that have corresponding trace data
+        const xsltElementsWithTrace = xsltElements.filter((element) => {
+          const matchingTraceElements = inlineTraceElements.filter((traceElement) => {
+            const traceId = traceElement.StepId || traceElement.ModelStepId;
+            return traceId === element.id;
+          });
+          return matchingTraceElements.length > 0;
+        });
+
+        if (xsltElementsWithTrace.length === 0) {
+          $("#cpiHelper_waiting_model").modal("hide");
+          showToast("No XSLT steps with trace data found in this message", "XSLT Debugger", "Warning");
+          return;
+        }
+
+        // Highlight only XSLT mapping elements that have trace data
+        applyXSLTHighlighting(xsltElementsWithTrace);
+
+        // Store data for click handling
+        window.xsltDebuggerData = {
+          settings: settings,
+          runInfo: runInfo,
+          xsltElements: xsltElementsWithTrace,
+          iFlowData: iFlowData,
+          iFlowUrl: iFlowUrl,
+          artifactId: artifactId,
+          inlineTraceElements: inlineTraceElements,
+        };
+
+        setupXSLTClickHandlers(settings, runInfo, xsltElementsWithTrace, iFlowData, artifactId, pluginHelper.tenant);
+
+        $("#cpiHelper_waiting_model").modal("hide");
+        showToast("XSLT steps with data highlighted - click on any highlighted XSLT step to debug", "Success");
+      } catch (error) {
+        log.error("Error in XSLT Debugger:", error);
+        showToast("Error: " + error.message, "XSLT Debugger", "Error");
+        $("#cpiHelper_waiting_model").modal("hide");
+      }
+    },
+    condition: (pluginHelper, settings, runInfo) => {
+      var date = new Date();
+      date.setHours(date.getHours() - 1);
+      return runInfo.logLevel === "trace" && runInfo.logStart > date;
+    },
+  },
+};
+
+/**
+ * Resets all XSLT highlighting and removes click handlers from BPMN shape elements.
+ * Clears the fill color and cursor styles from all elements.
+ * @function resetXSLTHighlighting
+ */
+function resetXSLTHighlighting() {
+  document.querySelectorAll("g[id^='BPMNShape_'] rect.activity").forEach((rect) => {
+    rect.style.fill = "";
+  });
+  document.querySelectorAll("g[id^='BPMNShape_']").forEach((element) => {
+    element.style.cursor = "";
+    element.onclick = null;
+  });
+}
+
+/**
+ * Extracts XSLT mapping elements from the integration flow JSON data.
+ * Filters elements to find only those with displayName "XSLT Mapping".
+ * @function extractXSLTElements
+ * @param {Object} iFlowData - The integration flow JSON structure
+ * @returns {Array} Array of XSLT mapping elements with id, displayName, mappingPath, and filename
+ */
+function extractXSLTElements(iFlowData) {
+  if (!iFlowData.propertyViewModel?.listOfDefaultFlowElementModel) {
+    return [];
+  }
+
+  return iFlowData.propertyViewModel.listOfDefaultFlowElementModel
+    .filter((element) => element.displayName === "XSLT Mapping")
+    .map((element) => {
+      const mappingPath = element.allAttributes?.mappingpath?.value || "";
+      const filename = mappingPath.split("/").pop() || mappingPath;
+      return {
+        id: element.id,
+        name: element.name || element.displayName,
+        displayName: element.displayName,
+        mappingPath: mappingPath,
+        filename: filename,
+      };
+    });
+}
+
+/**
+ * Applies green highlighting to found XSLT elements on the BPMN diagram.
+ * Sets fill color to green (#13af00) for visual indication of debuggable steps.
+ * @function applyXSLTHighlighting
+ * @param {Array} xsltElements - Array of XSLT mapping elements to highlight
+ */
+function applyXSLTHighlighting(xsltElements) {
+  xsltElements.forEach((element) => {
+    const selector = `g#BPMNShape_${element.id}`;
+    const targetElement = document.querySelector(selector);
+
+    if (targetElement) {
+      const rectElement = targetElement.querySelector("rect.activity");
+      if (rectElement) {
+        rectElement.style.fill = "#13af00";
+      }
+    }
+  });
+}
+
+/**
+ * Sets up click handlers for highlighted XSLT elements.
+ * When clicked, displays debug popup with trace data for the selected XSLT step.
+ * @function setupXSLTClickHandlers
+ * @param {Object} settings - Plugin settings
+ * @param {Object} runInfo - Runtime information for the message
+ * @param {Array} xsltElements - Array of XSLT mapping elements
+ * @param {Object} iFlowData - Integration flow JSON data
+ * @param {string} artifactId - Artifact identifier
+ * @param {string} tenant - Tenant name
+ */
+function setupXSLTClickHandlers(settings, runInfo, xsltElements, iFlowData, artifactId, tenant) {
+  xsltElements.forEach((element) => {
+    const selector = `g#BPMNShape_${element.id}`;
+    const targetElement = document.querySelector(selector);
+
+    if (targetElement) {
+      targetElement.style.cursor = "pointer";
+      targetElement.onclick = async (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+
+        try {
+          let debugData = await tryGetXSLTTraceDataForElement(runInfo, element, window.xsltDebuggerData.inlineTraceElements);
+
+          if (!debugData) {
+            debugData = {
+              messageGuid: runInfo.messageGuid,
+              stepId: element.id,
+              scriptName: element.displayName,
+              timestamp: new Date().toISOString(),
+            };
+          }
+
+          // Store script fetching info for lazy loading
+          debugData.scriptInfo = {
+            tenant: tenant,
+            artifactId: artifactId,
+            filename: element.filename,
+          };
+
+          showBigPopup(await createXSLTDebugContent(debugData), `XSLT Debug Data - ${element.name || element.displayName || element.id}`, {
+            fullscreen: false,
+            callback: () => {
+              let actionsDiv = $("#cpiHelper_semanticui_modal .actions");
+              let debugBtn = $('<div class="ui positive button"><i class="rocket icon"></i>Debug Externally</div>');
+              debugBtn.on("click", () => window.xsltDebugSendToIDE());
+              actionsDiv.prepend(debugBtn);
+            },
+          });
+        } catch (error) {
+          log.error("Error in XSLT click handler:", error);
+          showToast("Error: " + error.message, "Error");
+        }
+      };
+    }
+  });
+}
+
+/**
+ * Attempts to get trace data for a specific XSLT element using pre-fetched trace elements.
+ * @async
+ * @function tryGetXSLTTraceDataForElement
+ * @param {Object} runInfo - Runtime information for the message
+ * @param {Object} element - XSLT element to find trace data for
+ * @param {Array} inlineTraceElements - Array of pre-fetched trace elements
+ * @returns {Promise<Object|null>} Debug data object if found, null otherwise
+ */
+async function tryGetXSLTTraceDataForElement(runInfo, element, inlineTraceElements) {
+  try {
+    if (!inlineTraceElements?.length) {
+      return null;
+    }
+
+    const matchingTraceElements = inlineTraceElements.filter((traceElement) => {
+      const traceId = traceElement.StepId || traceElement.ModelStepId;
+      return traceId === element.id;
+    });
+
+    if (matchingTraceElements.length === 0) {
+      return null;
+    }
+
+    return await fetchXSLTDebugData(runInfo, matchingTraceElements[0]);
+  } catch (error) {
+    log.error("Error getting trace data for XSLT element:", error);
+    return null;
+  }
+}
+
+/**
+ * Fetches debug data for a specific XSLT step from the CPI API.
+ * Retrieves trace messages, exchange properties, and run step information.
+ * @async
+ * @function fetchXSLTDebugData
+ * @param {Object} runInfo - Runtime information containing message GUID
+ * @param {Object} xsltStep - Trace element data for the XSLT step
+ * @returns {Promise<Object|null>} Complete debug data object or null if failed
+ */
+async function fetchXSLTDebugData(runInfo, xsltStep) {
+  try {
+    var messageGuid = runInfo.messageGuid;
+    var runId = xsltStep.RunId;
+    var childCount = xsltStep.ChildCount;
+
+    // Get trace messages for this step
+    var traceData = JSON.parse(
+      await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/MessageProcessingLogRunSteps(RunId='" + runId + "',ChildCount=" + childCount + ")/TraceMessages?$format=json", true)
+    ).d.results;
+
+    var traceInfo = traceData.find((trace) => trace.TraceId);
+
+    if (!traceInfo) {
+      return null;
+    }
+
+    var traceId = traceInfo.TraceId;
+
+    // Get exchange properties
+    var properties = {};
+    try {
+      var propsData = JSON.parse(await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + traceId + ")/ExchangeProperties?$format=json", true)).d.results;
+      propsData.forEach((prop) => {
+        properties[prop.Name] = prop.Value;
+      });
+    } catch (e) {
+      log.log("No properties for this XSLT step");
+    }
+
+    // Get run step data with properties for Log and Info tabs
+    var runStepData = {};
+    try {
+      runStepData = JSON.parse(
+        await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/MessageProcessingLogRunSteps(RunId='" + runId + "',ChildCount=" + childCount + ")/?$expand=RunStepProperties&$format=json", true)
+      ).d;
+    } catch (e) {
+      log.log("No run step data for this XSLT step");
+    }
+
+    return {
+      messageGuid: messageGuid,
+      stepId: xsltStep.StepId,
+      runId: runId,
+      childCount: childCount,
+      traceId: traceId,
+      properties: properties,
+      runStepData: runStepData,
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
+    log.error("Error fetching XSLT debug data:", error);
+    return null;
+  }
+}
+
+/**
+ * Creates the HTML content for the XSLT debug popup with multiple tabs.
+ * Uses lazy loading for performance - content is fetched only when tabs are activated.
+ * @async
+ * @function createXSLTDebugContent
+ * @param {Object} data - Debug data object containing trace information
+ * @returns {Promise<string>} HTML content for the debug popup tabs
+ */
+async function createXSLTDebugContent(data) {
+  // Lazy load body content when Body tab is activated
+  let bodyContent = async () => {
+    if (!data.traceId) return "<div>No trace data available for this step.</div>";
+    try {
+      let payload = await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + data.traceId + ")/$value", true);
+      return formatTrace(payload || "No payload", "xsltDebugBody", null, "payload.txt");
+    } catch (error) {
+      log.error("Error fetching XSLT body content:", error);
+      return "<div>No body data available</div>";
+    }
+  };
+
+  // Lazy load headers content when Headers tab is activated
+  let headersContent = async () => {
+    if (!data.traceId) return "<div>No trace data available for this step.</div>";
+    try {
+      let headersData = JSON.parse(await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + data.traceId + ")/Properties?$format=json", true)).d.results;
+      let headers = {};
+      headersData.forEach((header) => {
+        headers[header.Name] = header.Value;
+      });
+      return formatHeadersAndPropertiesToTable(
+        Object.keys(headers)
+          .sort()
+          .map((key) => ({ Name: key, Value: headers[key] }))
+      );
+    } catch (error) {
+      log.error("Error fetching XSLT headers content:", error);
+      return "<div>No headers data available</div>";
+    }
+  };
+
+  let propertiesContent = formatHeadersAndPropertiesToTable(
+    data.properties
+      ? Object.keys(data.properties)
+          .sort()
+          .map((key) => ({ Name: key, Value: data.properties[key] }))
+      : []
+  );
+
+  // Lazy load XSLT script content when Script tab is activated
+  let scriptContent = async () => {
+    try {
+      const scriptUrl = resolveXSLTScriptUrl(data.scriptInfo);
+      let xsltScriptContent = "<!-- XSLT script content not available -->";
+      if (scriptUrl) {
+        const scriptResponse = await fetch(scriptUrl);
+        const scriptData = await scriptResponse.json();
+        xsltScriptContent = scriptData.content || "<!-- XSLT script content not available -->";
+      }
+      return formatTrace(xsltScriptContent, "xsltDebugScript", null, "script.xsl");
+    } catch (error) {
+      log.error("Error fetching XSLT script content:", error);
+      return formatTrace("<!-- Error loading XSLT script content -->", "xsltDebugScript", null, "script.xsl");
+    }
+  };
+
+  // Get Log content from stored run step data
+  let logContent = formatXSLTLogContent(data.runStepData?.RunStepProperties?.results || []);
+
+  // Get Info content from stored run step data
+  let infoContent = formatXSLTInfoContent(data.runStepData || {});
+
+  let objects = [
+    { label: "Properties", content: propertiesContent, active: true },
+    { label: "Headers", content: headersContent, active: false },
+    { label: "Body", content: bodyContent, active: false },
+    { label: "Script", content: scriptContent, active: false },
+    { label: "Log", content: logContent, active: false },
+    { label: "Info", content: infoContent, active: false },
+  ];
+
+  let tabsContent = await createTabHTML(objects, "xsltDebugTabs");
+
+  // Store data globally for button access
+  window.currentXSLTDebugData = data;
+
+  return tabsContent;
+}
+
+/**
+ * Formats log content from run step properties into an HTML table.
+ * @function formatXSLTLogContent
+ * @param {Array} inputList - Array of log entries with Name and Value properties
+ * @returns {string} HTML table string containing formatted log content
+ */
+function formatXSLTLogContent(inputList) {
+  inputList = inputList.sort(function (a, b) {
+    return a.Name.toLowerCase() > b.Name.toLowerCase() ? 1 : -1;
+  });
+  let result = `<table class='ui basic striped selectable compact table'>
+  <thead><tr class="blue"><th>Name</th><th>Value</th></tr></thead>
+  <tbody>`;
+  inputList.forEach((item) => {
+    result += "<tr><td>" + item.Name + '</td><td style="word-break: break-all;">' + item.Value + "</td></tr>";
+  });
+  result += "</tbody></table>";
+  return result;
+}
+
+/**
+ * Formats run step information into an HTML table showing execution details.
+ * Calculates and displays start/end times and duration information.
+ * @function formatXSLTInfoContent
+ * @param {Object} inputList - Run step data containing execution information
+ * @returns {string} HTML table string containing formatted execution information
+ */
+function formatXSLTInfoContent(inputList) {
+  const valueList = [];
+
+  if (!inputList?.StepStart) {
+    return "<div class='ui message'>No execution info available for this step.</div>";
+  }
+
+  var stepStart = new Date(parseInt(inputList.StepStart.substr(6, 13)));
+
+  valueList.push({
+    Name: "Start Time",
+    Value: stepStart.toISOString().substr(0, 23),
+  });
+
+  if (inputList.StepStop) {
+    var stepStop = new Date(parseInt(inputList.StepStop.substr(6, 13)));
+    valueList.push({
+      Name: "End Time",
+      Value: stepStop.toISOString().substr(0, 23),
+    });
+    valueList.push({
+      Name: "Duration in milliseconds",
+      Value: stepStop - stepStart,
+    });
+    valueList.push({
+      Name: "Duration in seconds",
+      Value: (stepStop - stepStart) / 1000,
+    });
+    valueList.push({
+      Name: "Duration in minutes",
+      Value: (stepStop - stepStart) / 1000 / 60,
+    });
+  }
+
+  valueList.push({ Name: "BranchId", Value: inputList.BranchId });
+  valueList.push({ Name: "RunId", Value: inputList.RunId });
+  valueList.push({ Name: "StepId", Value: inputList.StepId });
+  valueList.push({ Name: "ModelStepId", Value: inputList.ModelStepId });
+  valueList.push({ Name: "ChildCount", Value: inputList.ChildCount });
+
+  let result = `<table class='ui basic striped selectable compact table'><thead><tr class="blue"><th>Name</th><th>Value</th></tr></thead>
+  <tbody>`;
+  valueList.forEach((item) => {
+    result += "<tr><td>" + item.Name + '</td><td style="word-break: break-all;">' + item.Value + "</td></tr>";
+  });
+  result += "</tbody></table>";
+  return result;
+}
+
+/**
+ * Resolves the full XSLT resource fetch URL from scriptInfo.
+ * Uses the CPI resource API endpoint for XSLT mapping files.
+ * API: /api/1.0/iflows/{artifactId}/resource/{filename}?resourceLocation=mapping&resourcePersistenceType=&artifactType=
+ * @function resolveXSLTScriptUrl
+ * @param {Object} scriptInfo - Script metadata with tenant, artifactId, filename
+ * @returns {string|null} Full URL to fetch the XSLT script, or null if unavailable
+ */
+function resolveXSLTScriptUrl(scriptInfo) {
+  if (!scriptInfo?.filename) return null;
+  return `https://${scriptInfo.tenant}/api/1.0/iflows/${scriptInfo.artifactId}/resource/${encodeURIComponent(scriptInfo.filename)}?resourceLocation=mapping&resourcePersistenceType=&artifactType=`;
+}
+
+/**
+ * Gathers and lazy-fetches all transfer data (script, payload, headers, properties)
+ * based on the transfer options selected by the user.
+ * @async
+ * @function resolveXSLTTransferData
+ * @param {Object} debugData - Complete debug data object
+ * @param {Object} transferOptions - Which data types to transfer
+ * @returns {Promise<{xsltScript: string, payload: string, headers: Object, properties: Object}>}
+ */
+async function resolveXSLTTransferData(debugData, transferOptions) {
+  let xsltScript = "";
+  if (transferOptions.script) {
+    const scriptUrl = resolveXSLTScriptUrl(debugData.scriptInfo);
+    if (scriptUrl) {
+      try {
+        const scriptResponse = await fetch(scriptUrl);
+        const scriptData = await scriptResponse.json();
+        xsltScript = scriptData.content || "";
+      } catch (e) {
+        log.error("Error fetching XSLT script for IDE:", e);
+        xsltScript = "";
+      }
+    }
+  }
+
+  let payload = "";
+  if (transferOptions.body) {
+    payload = debugData.payload || "";
+    if (!payload && debugData.traceId) {
+      try {
+        payload = await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + debugData.traceId + ")/$value", true);
+      } catch (e) {
+        log.error("Error fetching payload for XSLT IDE:", e);
+      }
+    }
+  }
+
+  let headers = {};
+  if (transferOptions.headers) {
+    headers = debugData.headers || {};
+    if (Object.keys(headers).length === 0 && debugData.traceId) {
+      try {
+        const headersData = JSON.parse(await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + debugData.traceId + ")/Properties?$format=json", true)).d.results;
+        headersData.forEach((h) => {
+          headers[h.Name] = h.Value;
+        });
+      } catch (e) {
+        log.error("Error fetching headers for XSLT IDE:", e);
+      }
+    }
+  }
+
+  const properties = transferOptions.properties ? debugData.properties || {} : {};
+
+  return { xsltScript, payload, headers, properties };
+}
+
+/**
+ * Sends XSLT debug data to an external XSLT IDE.
+ * The target URL is read from settings: if ideSelection is "custom" the user-supplied
+ * customIdeUrl is used, otherwise ideSelection itself is the URL.
+ * Data is encoded using pako.deflateRaw compression + URL-safe base64 and appended
+ * as a #share/ hash fragment so the IDE can decode it on load.
+ * @async
+ * @function sendToXSLTIDE
+ * @param {Object} settings - Plugin settings
+ * @param {Object} debugData - Complete debug data object
+ * @param {Object} transferOptions - Options for which data types to transfer
+ * @returns {Promise<void>} Resolves when the IDE tab has been opened
+ */
+async function sendToXSLTIDE(settings, debugData, transferOptions = { body: true, properties: true, headers: true, script: true }) {
+  const ideSelection = settings["xsltDebugX---ideSelection"] || "https://xsltdebugx.pages.dev/";
+  const customUrl = settings["xsltDebugX---customIdeUrl"] || "";
+  const ideUrl = ideSelection === "custom" ? customUrl.trim() || "https://xsltdebugx.pages.dev/" : ideSelection;
+
+  const { xsltScript, payload, headers, properties } = await resolveXSLTTransferData(debugData, transferOptions);
+
+  const sharePayload = {
+    xml:        payload,
+    xslt:       xsltScript,
+    headers:    Object.keys(headers).map(name    => ({ name, value: headers[name] })),
+    properties: Object.keys(properties).map(name => ({ name, value: properties[name] })),
+  };
+
+  // Compress with pako.deflateRaw + URL-safe base64 (matches xsltdebugx.pages.dev share format)
+  const bytes      = new TextEncoder().encode(JSON.stringify(sharePayload));
+  const compressed = pako.deflateRaw(bytes, { level: 9 });
+  const CHUNK = 8192;
+  let binary = '';
+  for (let i = 0; i < compressed.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(null, compressed.subarray(i, i + CHUNK));
+  }
+  const encoded = btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+  const baseUrl = ideUrl.split('#')[0];
+  window.open(baseUrl + '#share/' + encoded, "_blank");
+}
+
+pluginList.push(plugin);

--- a/plugins/xsltDebugX.js
+++ b/plugins/xsltDebugX.js
@@ -12,14 +12,20 @@ if (!window.xsltDebugSendToIDE) {
    * @returns {Promise<void>} Resolves when the IDE tab has been opened, or returns
    *   early if no IDE is selected or no debug data is available.
    */
-  window.xsltDebugSendToIDE = async function () {
+  window.xsltDebugSendToIDE = async function (debugDataOverride) {
     const settings = await getPluginSettings("xsltDebugX");
     // Default to the built-in IDE if user hasn't visited settings yet
     const ideSelection = settings["xsltDebugX---ideSelection"] || "https://xsltdebugx.pages.dev/";
 
     const customUrl = settings["xsltDebugX---customIdeUrl"] || "";
     const ideUrl = ideSelection === "custom" ? customUrl.trim() || "https://xsltdebugx.pages.dev/" : ideSelection;
-    const domain = new URL(ideUrl).hostname;
+    let domain;
+    try {
+      domain = new URL(ideUrl).hostname;
+    } catch (e) {
+      showToast("Invalid IDE URL: " + ideUrl, "XSLT Debugger", "Error");
+      return;
+    }
 
     // Load last-used transfer preferences (defaults: body+script on, properties+headers off)
     const [_body, _script, _props, _hdrs] = await Promise.all([
@@ -45,30 +51,30 @@ if (!window.xsltDebugSendToIDE) {
           <i class="info circle icon"></i>
           <strong>Privacy Notice:</strong> The selected data may contain sensitive business information. Proceed with caution.
         </div>
-        <p><strong>Destination:</strong> ${domain}</p>
+        <p><strong>Destination:</strong> ${htmlEscape(domain)}</p>
         <p>Select which data you want to transfer to the external XSLT WebIDE:</p>
         <div class="ui form">
           <div class="grouped fields">
             <div class="field">
-              <div class="ui checkbox ${prefs.body ? "checked" : ""}" id="xslt-transfer-body">
+              <div class="ui toggle checkbox" id="xslt-transfer-body">
                 <input type="checkbox" name="xslt-transfer-body" ${prefs.body ? "checked" : ""}>
                 <label>Message Body <em>(may contain sensitive data)</em></label>
               </div>
             </div>
             <div class="field">
-              <div class="ui checkbox ${prefs.script ? "checked" : ""}" id="xslt-transfer-script">
+              <div class="ui toggle checkbox" id="xslt-transfer-script">
                 <input type="checkbox" name="xslt-transfer-script" ${prefs.script ? "checked" : ""}>
                 <label>XSLT Script <em>(source code)</em></label>
               </div>
             </div>
             <div class="field">
-              <div class="ui checkbox ${prefs.properties ? "checked" : ""}" id="xslt-transfer-properties">
+              <div class="ui toggle checkbox" id="xslt-transfer-properties">
                 <input type="checkbox" name="xslt-transfer-properties" ${prefs.properties ? "checked" : ""}>
                 <label>Properties <em>(may contain configuration data)</em></label>
               </div>
             </div>
             <div class="field">
-              <div class="ui checkbox ${prefs.headers ? "checked" : ""}" id="xslt-transfer-headers">
+              <div class="ui toggle checkbox" id="xslt-transfer-headers">
                 <input type="checkbox" name="xslt-transfer-headers" ${prefs.headers ? "checked" : ""}>
                 <label>Headers <em>(may contain security & metadata)</em></label>
               </div>
@@ -102,9 +108,9 @@ if (!window.xsltDebugSendToIDE) {
           continueBtn.toggleClass("disabled", !anyChecked).prop("disabled", !anyChecked);
         };
 
-        $("#cpiHelper_semanticui_modal .ui.checkbox input").on("change", function () {
-          $(this).closest(".ui.checkbox").toggleClass("checked", $(this).prop("checked"));
-          updateContinueButton();
+        // Initialize Semantic UI toggle checkboxes
+        $("#cpiHelper_semanticui_modal .ui.checkbox").checkbox({
+          onChange: updateContinueButton,
         });
 
         updateContinueButton();
@@ -130,7 +136,7 @@ if (!window.xsltDebugSendToIDE) {
 
           $("#cpiHelper_semanticui_modal").modal("hide");
 
-          const debugData = window.currentXSLTDebugData;
+          const debugData = debugDataOverride || window.currentXSLTDebugData;
           if (!debugData) {
             showToast("No debug data available. Please click an XSLT step first.", "XSLT Debugger", "Error");
             return;
@@ -148,6 +154,8 @@ if (!window.xsltDebugSendToIDE) {
     });
   };
 }
+
+const xsltOriginalHandlers = new Map();
 
 var plugin = {
   metadataVersion: "1.0.0",
@@ -235,7 +243,8 @@ var plugin = {
 
         // Get trace elements to identify which XSLT steps have been executed
         await createInlineTraceElements(runInfo.messageGuid, false);
-        if (!inlineTraceElements?.length) {
+        const traceElementsCopy = [...inlineTraceElements];
+        if (!traceElementsCopy.length) {
           $("#cpiHelper_waiting_model").modal("hide");
           showToast("No trace data found for this message", "XSLT Debugger", "Warning");
           return;
@@ -243,7 +252,7 @@ var plugin = {
 
         // Find XSLT elements that have corresponding trace data
         const xsltElementsWithTrace = xsltElements.filter((element) => {
-          const matchingTraceElements = inlineTraceElements.filter((traceElement) => {
+          const matchingTraceElements = traceElementsCopy.filter((traceElement) => {
             const traceId = traceElement.StepId || traceElement.ModelStepId;
             return traceId === element.id;
           });
@@ -267,7 +276,7 @@ var plugin = {
           iFlowData: iFlowData,
           iFlowUrl: iFlowUrl,
           artifactId: artifactId,
-          inlineTraceElements: inlineTraceElements,
+          inlineTraceElements: traceElementsCopy,
         };
 
         setupXSLTClickHandlers(settings, runInfo, xsltElementsWithTrace, iFlowData, artifactId, pluginHelper.tenant);
@@ -299,8 +308,9 @@ function resetXSLTHighlighting() {
   });
   document.querySelectorAll("g[id^='BPMNShape_']").forEach((element) => {
     element.style.cursor = "";
-    element.onclick = null;
+    element.onclick = xsltOriginalHandlers.get(element.id) || null;
   });
+  xsltOriginalHandlers.clear();
 }
 
 /**
@@ -367,6 +377,9 @@ function setupXSLTClickHandlers(settings, runInfo, xsltElements, iFlowData, arti
     const targetElement = document.querySelector(selector);
 
     if (targetElement) {
+      if (!xsltOriginalHandlers.has(targetElement.id)) {
+        xsltOriginalHandlers.set(targetElement.id, targetElement.onclick);
+      }
       targetElement.style.cursor = "pointer";
       targetElement.onclick = async (event) => {
         event.stopPropagation();
@@ -396,7 +409,7 @@ function setupXSLTClickHandlers(settings, runInfo, xsltElements, iFlowData, arti
             callback: () => {
               let actionsDiv = $("#cpiHelper_semanticui_modal .actions");
               let debugBtn = $('<div class="ui positive button"><i class="rocket icon"></i>Debug Externally</div>');
-              debugBtn.on("click", () => window.xsltDebugSendToIDE());
+              debugBtn.on("click", () => window.xsltDebugSendToIDE(debugData));
               actionsDiv.prepend(debugBtn);
             },
           });
@@ -519,6 +532,9 @@ async function createXSLTDebugContent(data) {
     if (!data.traceId) return "<div>No trace data available for this step.</div>";
     try {
       let payload = await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + data.traceId + ")/$value", true);
+      if (typeof payload === "string" && payload) {
+        data.payload = payload;
+      }
       return formatTrace(payload || "No payload", "xsltDebugBody", null, "payload.txt");
     } catch (error) {
       log.error("Error fetching XSLT body content:", error);
@@ -535,6 +551,7 @@ async function createXSLTDebugContent(data) {
       headersData.forEach((header) => {
         headers[header.Name] = header.Value;
       });
+      data.headers = headers;
       return formatHeadersAndPropertiesToTable(
         Object.keys(headers)
           .sort()
@@ -561,8 +578,13 @@ async function createXSLTDebugContent(data) {
       let xsltScriptContent = "<!-- XSLT script content not available -->";
       if (scriptUrl) {
         const scriptResponse = await fetch(scriptUrl);
-        const scriptData = await scriptResponse.json();
-        xsltScriptContent = scriptData.content || "<!-- XSLT script content not available -->";
+        if (scriptResponse.ok) {
+          const scriptData = await scriptResponse.json();
+          if (scriptData.content) {
+            xsltScriptContent = scriptData.content;
+            data.xsltScript = xsltScriptContent;
+          }
+        }
       }
       return formatTrace(xsltScriptContent, "xsltDebugScript", null, "script.xsl");
     } catch (error) {
@@ -608,7 +630,7 @@ function formatXSLTLogContent(inputList) {
   <thead><tr class="blue"><th>Name</th><th>Value</th></tr></thead>
   <tbody>`;
   inputList.forEach((item) => {
-    result += "<tr><td>" + item.Name + '</td><td style="word-break: break-all;">' + item.Value + "</td></tr>";
+    result += "<tr><td>" + htmlEscape(item.Name) + '</td><td style="word-break: break-all;">' + htmlEscape(item.Value) + "</td></tr>";
   });
   result += "</tbody></table>";
   return result;
@@ -664,7 +686,7 @@ function formatXSLTInfoContent(inputList) {
   let result = `<table class='ui basic striped selectable compact table'><thead><tr class="blue"><th>Name</th><th>Value</th></tr></thead>
   <tbody>`;
   valueList.forEach((item) => {
-    result += "<tr><td>" + item.Name + '</td><td style="word-break: break-all;">' + item.Value + "</td></tr>";
+    result += "<tr><td>" + htmlEscape(item.Name) + '</td><td style="word-break: break-all;">' + htmlEscape(String(item.Value)) + "</td></tr>";
   });
   result += "</tbody></table>";
   return result;
@@ -695,15 +717,19 @@ function resolveXSLTScriptUrl(scriptInfo) {
 async function resolveXSLTTransferData(debugData, transferOptions) {
   let xsltScript = "";
   if (transferOptions.script) {
-    const scriptUrl = resolveXSLTScriptUrl(debugData.scriptInfo);
-    if (scriptUrl) {
-      try {
-        const scriptResponse = await fetch(scriptUrl);
-        const scriptData = await scriptResponse.json();
-        xsltScript = scriptData.content || "";
-      } catch (e) {
-        log.error("Error fetching XSLT script for IDE:", e);
-        xsltScript = "";
+    xsltScript = debugData.xsltScript || "";
+    if (!xsltScript) {
+      const scriptUrl = resolveXSLTScriptUrl(debugData.scriptInfo);
+      if (scriptUrl) {
+        try {
+          const scriptResponse = await fetch(scriptUrl);
+          if (scriptResponse.ok) {
+            const scriptData = await scriptResponse.json();
+            xsltScript = scriptData.content || "";
+          }
+        } catch (e) {
+          log.error("Error fetching XSLT script for IDE:", e);
+        }
       }
     }
   }
@@ -713,7 +739,10 @@ async function resolveXSLTTransferData(debugData, transferOptions) {
     payload = debugData.payload || "";
     if (!payload && debugData.traceId) {
       try {
-        payload = await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + debugData.traceId + ")/$value", true);
+        const result = await makeCallPromise("GET", "/" + cpiData.urlExtension + cpiData.runtimePathExtension + "odata/api/v1/TraceMessages(" + debugData.traceId + ")/$value", true);
+        if (typeof result === "string") {
+          payload = result;
+        }
       } catch (e) {
         log.error("Error fetching payload for XSLT IDE:", e);
       }
@@ -757,6 +786,11 @@ async function sendToXSLTIDE(settings, debugData, transferOptions = { body: true
   const ideSelection = settings["xsltDebugX---ideSelection"] || "https://xsltdebugx.pages.dev/";
   const customUrl = settings["xsltDebugX---customIdeUrl"] || "";
   const ideUrl = ideSelection === "custom" ? customUrl.trim() || "https://xsltdebugx.pages.dev/" : ideSelection;
+
+  if (typeof pako === "undefined") {
+    showToast("Compression library not loaded. Please reload the page.", "XSLT Debugger", "Error");
+    return;
+  }
 
   const { xsltScript, payload, headers, properties } = await resolveXSLTTransferData(debugData, transferOptions);
 


### PR DESCRIPTION
### Summary                                            

  Adds a new **xsltDebugX** plugin for debugging XSLT mappings via an external WebIDE, and applies security
  and reliability hardening to both plugins.

  ### New: xsltDebugX plugin (`plugins/xsltDebugX.js`)
  - Debug XSLT mappings by clicking traced steps directly on the IFlow diagram
  - View message body, headers, properties, and XSLT script source in a tabbed debug panel
  - "Debug Externally" button transfers selected data to a  configurable external XSLT WebIDE (default:
  xsltdebugx.pages.dev)
  - Privacy-aware transfer modal with toggle checkboxes for selecting which data to send
  - Configurable IDE URL via plugin settings (built-in or custom)
  - Data compressed with pako and sent via URL fragment — no server-side storage
  - Fully self-contained — no dependency on groovyDebugger plugin

  ### Hardened: groovyDebugger plugin (`plugins/groovyDebugger.js`)
  The following fixes were applied to both plugins for consistency:

  **Security**
  - XSS prevention: `htmlEscape()` on all user-facing data in HTML tables and popup content
  - IDE URL validation: `new URL()` wrapped in try/catch with user-friendly error toast

  **Reliability**
  - Preserve and restore SAP's native click handlers on plugin deactivate (via Map)
  - Snapshot `inlineTraceElements` to local array to prevent mutation from concurrent calls
  - `getArtifactIdDirectly` call wrapped in try/catch with error toast
  - `response.ok` checks before parsing fetch responses
  - `pako`/`JSZip` availability guards before compression
  - Pass `debugData` directly to IDE transfer function instead of relying on stale global

  **Performance**
  - Cache fetched payload, headers, and script on the debug data object so IDE transfer reuses them without
  redundant API calls

  **UI**
  - Replaced plain checkboxes with Semantic UI toggle checkboxes
  - Use proper `.checkbox()` API instead of manual event handlers

  ### Code quality
  - Removed verbose JSDoc blocks from both plugins, kept only non-obvious WHY-comments