### PR TITLE
fix(plugins): pass cpiData to the heartbeat hook instead of the plugin object

### DIFF
--- a/scripts/plugins.js
+++ b/scripts/plugins.js
@@ -375,7 +375,7 @@ async function runPluginHeartbeat() {
     var settings = await getPluginSettings(plugin.id);
     if (settings[plugin.id + "---isActive"] === true) {
       if (plugin["heartbeat"]) {
-        await plugin["heartbeat"](plugin, settings);
+        await plugin["heartbeat"](cpiData, settings);
       }
     }
   }


### PR DESCRIPTION
__File Modified:__ `scripts/plugins.js`

### Problem

`runPluginHeartbeat()` calls the `heartbeat` hook with the plugin's own object as the first argument:

```js
await plugin["heartbeat"](plugin, settings);
```

Every other plugin hook receives `cpiData`, and `docs/readme/PluginREADME.md` documents that first parameter as `pluginHelper`. `plugins/example.js` declares the hook as `heartbeat: async (pluginHelper, settings) => {}` accordingly.

So a `heartbeat` plugin currently has no access to the tenant context every other hook gets — `urlExtension`, `currentIflowId`, `currentArtifactType`, `cpiData.functions.*`.

### Change

One line: pass `cpiData` instead of `plugin`, so `heartbeat` matches the documented contract and the other hooks.

### Not a breaking change

The three plugins implementing `heartbeat` today were checked and none of them reads the first argument:

- `plugins/environmentTrafficLight.js`
- `plugins/removeApacheUpdateMessage.js`
- `plugins/example.js` (template, logs only)
