### PR TITLE
feat(plugins/keepAlive): Add "Session Keep Alive" plugin against idle session timeouts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -76,6 +76,7 @@
         "/plugins/connectivityCredentialsManager.js",
         "/plugins/zz_developer_tools.js",
         "/plugins/iFlowSearcher.js",
+        "/plugins/keepAlive.js",
         "/scripts/ui.js",
         "/scripts/logs.js",
         "/whatsNew/whatsNewLog.js",

--- a/plugins/keepAlive.js
+++ b/plugins/keepAlive.js
@@ -1,0 +1,56 @@
+var keepAliveState = { lastPing: 0, lastStatus: "not pinged yet" };
+
+var plugin = {
+  metadataVersion: "1.0.0",
+  id: "keepAlive",
+  name: "Session Keep Alive",
+  version: "1.0.0",
+  author: "Alexander Aigner",
+  email: "alexander.aigner@snapconsult.com",
+  website: "https://www.linkedin.com/in/alexander-aigner-at/",
+  description:
+    "Sends a small request to the tenant in a fixed interval so the idle session timeout does not kick in while you are reading or writing code. This only helps against <b>idle</b> timeouts. A hard maximum session lifetime cannot be extended and you will still be logged out at some point.",
+
+  settings: {
+    info: {
+      text: "Interval in seconds between two keep alive requests. Empty or invalid values fall back to 30 seconds. The heartbeat ticks every 3 seconds, so the effective interval is rounded up to the next multiple of 3.",
+      type: "label",
+    },
+    intervalSeconds: {
+      text: "Interval (seconds)",
+      placeholder: "30",
+      type: "textinput",
+      scope: "browser",
+    },
+    showToast: {
+      text: "Show a toast on every keep alive request (for testing)",
+      type: "checkbox",
+      scope: "browser",
+    },
+  },
+
+  heartbeat: async (pluginHelper, settings) => {
+    const rawInterval = parseFloat(settings["keepAlive---intervalSeconds"]);
+    const intervalMs = (isNaN(rawInterval) || rawInterval <= 0 ? 30 : rawInterval) * 1000;
+
+    if (Date.now() - keepAliveState.lastPing < intervalMs) {
+      return;
+    }
+    keepAliveState.lastPing = Date.now();
+
+    // cheapest authenticated endpoint of the tenant (same one getCsrfToken uses); touching it resets the idle timer
+    const url = "/" + pluginHelper.urlExtension + "api/1.0/user";
+
+    // useCache=false and showInfo=false: never cached, no toast and no working indicator on failure
+    const response = await makeCallPromiseV2("GET", url, false, "application/json", undefined, false, undefined, false);
+
+    keepAliveState.lastStatus = `${new Date().toLocaleTimeString()}: ${response.successful ? "ok" : "failed"} (status ${response.status})`;
+    log.log("keepAlive: " + keepAliveState.lastStatus);
+
+    if (settings["keepAlive---showToast"] === true) {
+      showToast(keepAliveState.lastStatus, "Keep alive", response.successful ? "success" : "error");
+    }
+  },
+};
+
+pluginList.push(plugin);

--- a/scripts/plugins.js
+++ b/scripts/plugins.js
@@ -375,7 +375,7 @@ async function runPluginHeartbeat() {
     var settings = await getPluginSettings(plugin.id);
     if (settings[plugin.id + "---isActive"] === true) {
       if (plugin["heartbeat"]) {
-        await plugin["heartbeat"](plugin, settings);
+        await plugin["heartbeat"](cpiData, settings);
       }
     }
   }


### PR DESCRIPTION
This PR adds a new plugin `keepAlive` ("Session Keep Alive"). While active, it sends a small authenticated request to the tenant in a configurable interval, so the **idle** session timeout does not log you out while you are reading or writing code in the editor.

__Files:__ `plugins/keepAlive.js` (new), `manifest.json`

**What does this feature do?**

Runs on the `heartbeat` hook and self-throttles against its own timestamp, the same pattern the message sidebar refresh uses. Since the heartbeat ticks every 3 seconds, the effective interval is rounded up to the next multiple of 3.

The request goes to `/<urlExtension>api/1.0/user` — the same endpoint `getCsrfToken()` already uses, so the cheapest authenticated tenant call available. It goes through `makeCallPromiseV2` with `useCache = false` and `showInfo = false`, so nothing is cached and a failure produces no toast and no working indicator.

Only the tenant the user already has open is contacted, no external calls.

**Why is it useful?**

Reading through a large iFlow, writing a Groovy script or comparing traces easily takes longer than the idle timeout. Getting logged out mid-edit is the annoying part, and re-login does not always bring you back where you were.

This only helps against **idle** timeouts. A hard maximum session lifetime cannot be extended, and you will still be logged out at some point — the plugin description says so in the UI, so nobody expects more than it delivers.

**Settings** (scope `browser`)

| Setting | Type | Default |
| --- | --- | --- |
| Interval (seconds) | `textinput` | 30, also the fallback for empty or invalid input |
| Show a toast on every keep alive request | `checkbox` | off, for testing |

### Depends on #332

The plugin reads `pluginHelper.urlExtension`, which is only populated after the heartbeat argument fix in #332. This branch is stacked on that one and currently shows both commits; once #332 is merged it collapses to its own single commit. Merged on its own it would call `/undefinedapi/1.0/user`.
