### PR TITLE
feat(ui): Add Plugins tab to the global CPI Helper popup

### DIFF
--- a/scripts/Mode-Script.js
+++ b/scripts/Mode-Script.js
@@ -15,13 +15,16 @@ function navigationButton() {
         await showBigPopup(
           `<div class="ui blue secondary pointing centered fluid menu">
     <div class="active item" data-tab="homepage">Search Credentials & Log Mode</div>
+    <div class="item" data-tab="plugins">Plugins</div>
     </div>
-    <div data-tab="homepage" class="ui loading tab"><div id="GlobalCH_Tab1"></div></div>`,
+    <div data-tab="homepage" class="ui loading tab"><div id="GlobalCH_Tab1"></div></div>
+    <div data-tab="plugins" class="ui tab"><div id="GlobalCH_TabPlugins"></div></div>`,
           "",
           {
             fullscreen: true,
             callback: async () => {
               $("#cpiHelper_bigPopup_content_semanticui .blue.menu.secondary .item").tab();
+              $("#GlobalCH_TabPlugins").append(await createContentNodeForPlugins());
               await fromInitialLoadingTo();
             },
           }


### PR DESCRIPTION
__File Modified:__ `scripts/Mode-Script.js`

### Problem

Plugin activation is only reachable through the button bar inside the iFlow editor, because `buildButtonBar()` needs the UI5 element `[id*='--iflowObjectPageHeader-actions']` to exist. On a package list, in monitoring, or anywhere else in the tenant there is no way to reach the plugin list — including for plugins that are not iFlow-specific at all, such as `heartbeat` plugins that run on every matched page.

### Change

Adds a **Plugins** tab to the global CPI Helper popup — the shell toolbar button added by `navigationButton()`, available on every matched CPI page — next to the existing "Search Credentials & Log Mode" tab.

The tab content comes from the existing `createContentNodeForPlugins()` in `scripts/plugins.js`, so there is no second implementation of the list and both entry points stay in sync automatically.
