### PR TITLE
fix(inline-trace): resolve diagram nodes by id instead of type regex

### DIFF
--- a/scripts/inline-trace.js
+++ b/scripts/inline-trace.js
@@ -354,47 +354,15 @@ async function showInlineTrace(MessageGuid, checked = false) {
 
     inlineTraceElements.forEach((run) => {
       try {
-        let target;
-        let element;
-        let flag = true;
-        //    let target = element.children[getChild(element, ["g"])];
-        //    target = target.children[getChild(target, ["rect", "circle", "path"])];
-
-        if (/StartEvent/.test(run.ModelStepId)) {
-          element = document.getElementById("BPMNShape_" + run.ModelStepId);
-          target = element.children[0].children[0];
-          flag = false;
+        const resolved = resolveInlineTraceNode(run);
+        if (!resolved) {
+          log.log("no diagram element found for " + run.StepId + " / " + run.ModelStepId);
+          return;
         }
+        const element = resolved.element;
+        const target = resolved.target;
+        const flag = resolved.clickable;
 
-        if (/EndEvent/.test(run.StepId)) {
-          element = document.getElementById("BPMNShape_" + run.StepId);
-          target = element.children[0].children[0];
-        }
-
-        if (/ServiceTask/.test(run.StepId)) {
-          element = document.getElementById("BPMNShape_" + run.StepId);
-          target = element.children[getChild(element, ["g"])].children[0];
-        }
-
-        if (/CallActivity/.test(run.StepId)) {
-          element = document.getElementById("BPMNShape_" + run.StepId);
-          target = element.children[getChild(element, ["g"])].children[0];
-        }
-
-        if (/MessageFlow_\d+/.test(run.ModelStepId) && /#/.test(run.ModelStepId) != true) {
-          element = document.getElementById("BPMNEdge_" + run.ModelStepId);
-          target = element.children[getChild(element, ["text"], "shapeText")];
-        }
-
-        if (/ExclusiveGateway/.test(run.ModelStepId)) {
-          element = document.getElementById("BPMNShape_" + run.ModelStepId);
-          target = element.children[getChild(element, ["g"])].children[0];
-        }
-
-        if (/ParallelGateway/.test(run.ModelStepId)) {
-          element = document.getElementById("BPMNShape_" + run.ModelStepId);
-          target = element.children[getChild(element, ["g"])].children[0];
-        }
         element.setAttribute("inline_cpi_child", run.ChildCount);
         target.classList.add("cpiHelper_inlineInfo");
         //     target.addEventListener("onclick", function abc(event) { clickTrace(event); });
@@ -446,6 +414,81 @@ async function showInlineTrace(MessageGuid, checked = false) {
       return resolve(true);
     });
   });
+}
+
+/**
+ * Resolves the diagram element and the SVG element to highlight for one trace step.
+ *
+ * The node type used to be derived with regexes over the step id (/ServiceTask/,
+ * /CallActivity/, /ExclusiveGateway/, ...). That only holds for the ids SAP
+ * generates automatically. As soon as an iFlow uses custom element ids
+ * (CA_DSGet, GW_Ready, MF_SG) no regex matches, `element` stays undefined and
+ * nothing gets highlighted, even though the elements are present in the DOM.
+ *
+ * The element is now looked up by id, and the highlight target is derived from
+ * the SVG structure, which is the same for every node type.
+ *
+ * @param {object} run - a trace step (StepId, ModelStepId, ...).
+ * @returns {{element: Element, target: Element, clickable: boolean}|null} null when the step has no counterpart in the diagram.
+ */
+function resolveInlineTraceNode(run) {
+  const candidates = [];
+  const addCandidate = function (prefix, raw) {
+    if (raw === null || raw === undefined) {
+      return;
+    }
+    const value = String(raw);
+    if (!value) {
+      return;
+    }
+    candidates.push(prefix + value);
+    //some step ids carry an instance suffix, e.g. "MF_SG#1787289935763"
+    if (value.indexOf("#") > -1) {
+      candidates.push(prefix + value.split("#")[0]);
+    }
+  };
+
+  addCandidate("BPMNShape_", run.ModelStepId);
+  addCandidate("BPMNShape_", run.StepId);
+  addCandidate("BPMNEdge_", run.ModelStepId);
+  addCandidate("BPMNEdge_", run.StepId);
+
+  let element = null;
+  for (const id of candidates) {
+    element = document.getElementById(id);
+    if (element) {
+      break;
+    }
+  }
+  if (!element) {
+    return null;
+  }
+
+  let target = null;
+  if (element.id.indexOf("BPMNEdge_") === 0) {
+    //on message flows the text label is the element that gets coloured
+    let index = getChild(element, ["text"], "shapeText");
+    if (index === null) {
+      index = getChild(element, ["text"]);
+    }
+    target = index === null ? null : element.children[index];
+  } else {
+    //on shapes the first <g> child wraps the rect/circle that gets coloured.
+    //a <title> child is not always present, so a fixed index is not reliable.
+    const groupIndex = getChild(element, ["g"]);
+    if (groupIndex !== null && element.children[groupIndex].children.length > 0) {
+      target = element.children[groupIndex].children[0];
+    } else {
+      const shapeIndex = getChild(element, ["rect", "circle", "path", "polygon"]);
+      target = shapeIndex === null ? null : element.children[shapeIndex];
+    }
+  }
+  if (!target) {
+    return null;
+  }
+
+  //the start event opens no popup: there is no content "before" the start of the flow
+  return { element: element, target: target, clickable: !/StartEvent/i.test(element.id) };
 }
 
 function getChild(node, childNames, childClass = null) {

--- a/tests/inline-trace-custom-step-ids.js
+++ b/tests/inline-trace-custom-step-ids.js
@@ -1,0 +1,140 @@
+/*
+ * Regression test: inline trace on an iFlow with custom step ids.
+ *
+ * Reproduces an iFlow whose BPMN elements do NOT use the ids SAP generates
+ * automatically (CallActivity_5, ExclusiveGateway_2, ...) but custom ones
+ * (CA_DSGet, GW_Ready, MF_SG). Deriving the node type with regexes over the
+ * step id matched none of them, so no node was highlighted at all even though
+ * every element was present in the DOM.
+ *
+ * There is no test runner in this repo, so this is a standalone script:
+ *
+ *   node tests/inline-trace-custom-step-ids.js
+ *
+ * Exits 0 on success, 1 on failure.
+ */
+const fs = require("fs");
+const vm = require("vm");
+const path = require("path");
+
+const file = process.env.INLINE_TRACE_FILE || path.join(__dirname, "..", "scripts", "inline-trace.js");
+const code = fs.readFileSync(file, "utf8");
+
+function createClassList() {
+  const set = new Set();
+  return {
+    add(...n) {
+      n.forEach((x) => set.add(x));
+    },
+    remove(...n) {
+      n.forEach((x) => set.delete(x));
+    },
+    contains(x) {
+      return set.has(x);
+    },
+  };
+}
+
+function el(localName, cls) {
+  const node = { localName, children: [], classList: createClassList(), setAttribute() {}, onclick: null };
+  if (cls) node.classList.add(cls);
+  return node;
+}
+
+/** A BPMN shape as SAP renders it: <g>[<title>?]<g><rect class="activity">... */
+function makeShape(id, withTitle) {
+  const rect = el("rect", "activity");
+  const inner = el("g");
+  inner.children = [rect];
+  const node = el("g", "sapGalileiSymbolNode");
+  node.id = id;
+  node.children = withTitle ? [el("title"), inner] : [inner];
+  node.__paint = rect;
+  return node;
+}
+
+/** A message flow: the text label is what gets coloured. */
+function makeEdge(id) {
+  const label = el("text", "shapeText");
+  const node = el("g", "sapGalileiSymbolNode");
+  node.id = id;
+  node.children = [label];
+  node.__paint = label;
+  return node;
+}
+
+const nodes = {
+  BPMNShape_CA_DSGet: makeShape("BPMNShape_CA_DSGet", false), // no <title>
+  BPMNShape_CA_Key: makeShape("BPMNShape_CA_Key", true), // with <title>
+  BPMNShape_GW_Ready: makeShape("BPMNShape_GW_Ready", true),
+  BPMNShape_CM_Payload: makeShape("BPMNShape_CM_Payload", true),
+  BPMNShape_StartEvent_1: makeShape("BPMNShape_StartEvent_1", true),
+  BPMNEdge_MF_SG: makeEdge("BPMNEdge_MF_SG"),
+};
+
+// Steps as returned by the trace of such an iFlow
+const runs = [
+  { StepId: "CA_DSGet", ModelStepId: "CA_DSGet" },
+  { StepId: "CA_Key", ModelStepId: "CA_Key" },
+  { StepId: "GW_Ready", ModelStepId: "GW_Ready" },
+  { StepId: "CM_Payload", ModelStepId: "CM_Payload" },
+  { StepId: "MF_SG#1787289935763", ModelStepId: "MF_SG" }, // instance suffix
+  { StepId: null, ModelStepId: "StartEvent_1" }, // null StepId
+].map((r, i) => Object.assign({ ChildCount: i, StepStop: "/Date(2000)/", StepStart: "/Date(1000)/", RunId: "R" + i, BranchId: "B", Error: null }, r));
+
+const context = {
+  console,
+  document: {
+    getElementById: (id) => nodes[id] || null,
+    querySelectorAll: () => [],
+    querySelector: () => null,
+  },
+  MutationObserver: class {
+    observe() {}
+    disconnect() {}
+  },
+  getStorageValue: async () => false,
+  getMessageProcessingLogRuns: async () => runs,
+  log: { log() {}, error() {}, debug() {}, warn() {} },
+  onClicKElements: [],
+  showToast() {},
+  showBigPopup() {},
+  showWaitingPopup() {},
+  createTabHTML: async () => "<div></div>",
+  formatHeadersAndPropertiesToTable: () => "<table></table>",
+  $: () => ({ removeAttr() {}, toast() {} }),
+};
+context.window = context;
+vm.createContext(context);
+vm.runInContext(code, context);
+
+const fail = (msg) => {
+  console.error("FAILED: " + msg);
+  process.exit(1);
+};
+
+(async () => {
+  const result = await context.showInlineTrace("MSG1", false);
+  if (result !== true) fail("showInlineTrace returned " + result + ", expected true");
+
+  const notHighlighted = Object.keys(nodes).filter((id) => !nodes[id].__paint.classList.contains("cpiHelper_inlineInfo"));
+  if (notHighlighted.length) {
+    fail("these nodes were not highlighted although they exist in the DOM: " + notHighlighted.join(", "));
+  }
+
+  // the start event is highlighted but must not be clickable
+  if (nodes.BPMNShape_StartEvent_1.classList.contains("cpiHelper_onclick")) {
+    fail("the start event should not be clickable");
+  }
+  if (!nodes.BPMNShape_CA_DSGet.classList.contains("cpiHelper_onclick")) {
+    fail("CA_DSGet should be clickable");
+  }
+  if (context.onClicKElements.length !== 5) {
+    fail("expected 5 clickable elements, got " + context.onClicKElements.length);
+  }
+
+  console.log("OK: all 6 steps with custom ids are resolved and highlighted (5 clickable + start event).");
+})().catch((e) => {
+  console.error("FAILED with exception:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Inline trace highlights nothing when the iFlow uses custom BPMN element ids. The button reports "Inline-Debugging Activated" and the diagram stays untouched.

## The bug

`showInlineTrace()` derives the node type from regexes over the step id:

```js
if (/ServiceTask/.test(run.StepId))            { element = document.getElementById("BPMNShape_" + run.StepId); … }
if (/CallActivity/.test(run.StepId))           { … }
if (/ExclusiveGateway/.test(run.ModelStepId))  { … }
```

This assumes the id always contains the BPMN type keyword, which is only true for the ids SAP generates automatically (`CallActivity_5`, `ExclusiveGateway_2`, …). Element ids can be set to anything in the `.iflw` model, and plenty of teams do exactly that so the ids are readable in the trace and in monitoring.

When they are custom, none of the seven checks match, `element` stays `undefined`, and not a single node is highlighted.

## Evidence

Measured on an iFlow whose steps are named `CA_DSGet`, `CA_Key`, `CA_CM`, `GW_Ready`, `GW_1`, `CM_Payload`, `MF_SG`:

| | |
|---|---|
| Trace steps returned | 13 |
| Steps with a matching `BPMNShape_*` / `BPMNEdge_*` in the DOM | **13** |
| Steps matching any type regex | **0** |
| Nodes highlighted | 0 |

Running the seven regexes over all 31 element ids of that diagram, only 4 matched (`ServiceTask_SG`, `StartEvent_1`, `EndEvent_1`, `EndEvent_Skip`) — and none of those four appeared in the trace of the message being debugged.

This is not limited to exotic naming. `/MessageFlow_\d+/` requires digits, so a message flow called `MessageFlow_Sender` never matches either, despite looking like a stock SAP id.

## Why it fails silently

Two things hide it:

1. With `element === undefined`, the next line throws `TypeError: Cannot read properties of undefined (reading 'setAttribute')`. The per-step `try/catch` swallows it as `"no element found for …"`, which is easily lost in the SAP UI5 console noise.
2. `showInlineTrace()` resolves `true` regardless of how many nodes were processed, so the caller shows the "Inline-Debugging Activated" toast and marks the button active.

## The fix

`resolveInlineTraceNode()` separates the two concerns that were conflated in the id:

- **Locating the element** — `BPMNShape_` and `BPMNEdge_` are tried with both `ModelStepId` and `StepId`. Handles instance suffixes (`MF_SG#1787289935763`) and a null `StepId`.
- **Choosing what to colour** — derived from the SVG structure, which is identical across node types: the first `<g>` child and its first child for shapes, `text.shapeText` for message flows.

The id is used as an identifier only, never as a type declaration.

This also fixes start and end events, which used `element.children[0].children[0]`. That breaks whenever the node has a `<title>` first child, which SAP emits for some nodes and not others. **This part affects iFlows with default ids too.**

## Test

`tests/inline-trace-custom-step-ids.js` reproduces the case with the real ids. There is no test runner in the repo, so it is a standalone script:

```
node tests/inline-trace-custom-step-ids.js
```

- Against current `dev`: fails, 0 of 6 nodes highlighted.
- With this change: passes, 6 highlighted, 5 clickable plus the start event.

The default-id path is unaffected — verified separately with a fixture using `ServiceTask_1` / `ServiceTask_2`.

Happy to drop the test file or reshape it if it does not fit how you would like tests handled here.
